### PR TITLE
kogito-runtimes - enable integration-tests-quarkus-processes

### DIFF
--- a/run-tests-with-build-kogito-runtimes/pom.xml
+++ b/run-tests-with-build-kogito-runtimes/pom.xml
@@ -60,7 +60,6 @@
           </pomIncludes>
           <pomExcludes>
             <pomExclude>kogito-runtimes*/integration-tests/integration-tests-kogito-plugin/pom.xml</pomExclude>
-            <pomExclude>kogito-runtimes*/integration-tests/integration-tests-quarkus-processes/pom.xml</pomExclude>
             <pomExclude>kogito-runtimes*/integration-tests/integration-tests-springboot/pom.xml</pomExclude>
           </pomExcludes>
         </configuration>


### PR DESCRIPTION
Enabling the test in subject, it was previously failing due to no docker on the CI instance.

Verified in build no. 16.