### PR TITLE
Update settings.xml

### DIFF
--- a/settings/settings.xml
+++ b/settings/settings.xml
@@ -11,7 +11,7 @@
         <repository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <layout>default</layout>
           <snapshots>
             <enabled>true</enabled>
@@ -19,25 +19,13 @@
           <releases>
             <enabled>true</enabled>
           </releases>
-        </repository>
-        <repository>
-          <id>jboss-public-repository-group</id>
-          <name>JBoss Public Repository Group</name>
-          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-          </snapshots>
         </repository>
       </repositories>
       <pluginRepositories>
         <pluginRepository>
           <id>central</id>
           <name>Central Repository</name>
-          <url>http://repo.maven.apache.org/maven2</url>
+          <url>https://repo.maven.apache.org/maven2</url>
           <layout>default</layout>
           <snapshots>
             <enabled>true</enabled>
@@ -45,22 +33,9 @@
           <releases>
             <enabled>true</enabled>
           </releases>
-        </pluginRepository>
-        <pluginRepository>
-          <id>jboss-public-repository-group</id>
-          <name>JBoss Public Repository Group</name>
-          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>true</enabled>
-            <updatePolicy>daily</updatePolicy>
-          </snapshots>
         </pluginRepository>
       </pluginRepositories>
     </profile>
   </profiles>
+
 </settings>


### PR DESCRIPTION
Removed jboss repo to be consistent with testing repositories for product. To test if we have provided the dependency in product repository. Customers should be able to use Central and private MRRC.
Kogito group are at /kogito-master-nightly/ it contains
Central + JBoss.org public repo + scratch-release-kogito-master

It is recommended to avoid adding JBoss.org public repo in settings directly since it contains project SNAPSHOTS and we would not be able to catch issues if some snapshot was not updated at the product pipeline.

Use https fpr Maven central