### PR TITLE
decision-services-quickstarts module

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
     <module>run-tests-with-build-kogito-examples</module>
     <module>run-tests-with-build-kogito-runtimes</module>
     <module>run-tests-with-build-kogito-apps</module>
+    <module>run-tests-with-build-kogito-decision-services-quickstarts</module>
+    <module>run-tests-with-build-kogito-decision-services-quickstarts-optawebs</module>
     <module>run-tests-with-build-optaplanner-optawebs</module>
+    <module>run-tests-with-build-optaplanner-optawebs-parent</module>
   </modules>
 
   <properties>
@@ -56,6 +59,7 @@
     <jbpm.wb.repo.url>${git.server.url}/jbpm-wb</jbpm.wb.repo.url>
     <kie.wb.common.repo.url>${git.server.url}/kie-wb-common</kie.wb.common.repo.url>
     <kogito.examples.repo.url>${git.server.url}/kogito-examples</kogito.examples.repo.url>
+    <kogito.decision.services.quickstarts.url>NOT_SET</kogito.decision.services.quickstarts.url>
   </properties>
 
   <build>

--- a/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/README.md
+++ b/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/README.md
@@ -1,0 +1,33 @@
+run-tests-with-build-kogito-decision-services-quickstarts-optawebs
+------------------------------------
+Run tests OptaWeb backend, frontend and standalone, including integration delivered as part of decision-services-quickstarts zip
+
+Currently, these optawebs are delivered in decision-services-quickstarts zip
+- [optaweb-employee-rostering](https://github.com/kiegroup/optaweb-employee-rostering)
+- [optaweb-vehicle-routing](https://github.com/kiegroup/optaweb-vehicle-routing)
+
+Execution
+-------------------------------------
+`mvn verify -Doptaweb=$OPTAWEB_NAME -s $PROJECT_SETTINGS -Dkogito.decision.services.quickstarts.url=$QUICKSTARTS_URL`
+
+where 
+
+`$OPTAWEB_NAME` is a profile name {vehicle-routing|employee-rostering} 
+
+`$PROJECT_SETTINGS` is the settings.xml with the repository which contains ${OPTAPLANNER_BUILD_VERSION} tar.gz 
+
+`$QUICKSTARTS_URL` redhat distribution decision-services-quickstarts.zip url
+
+`-Dintegration-tests={true|false}` run integration cypress tests on docker
+
+`-Dcontainer.runtime={docker|podman}` change runtime
+
+To set up $PROJECT_SETTINGS file, provide there the mirror repository and npm repository e.g: 
+https://gist.githubusercontent.com/dupliaka/8c65bcbc6eb4eb931ea7124b1daa2228/raw/faa452c141fa1fa247ea724bf0006cf915ac4ad6/settings.xml
+
+---------------------------------------
+Issues
+
+`Unknown host ...` -  check if you are connected to the Kerberos
+
+`Artifact was not found at ...` - check if the repository of problem dependency was correct or if it already contains the artifact.

--- a/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/README.md
+++ b/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/README.md
@@ -14,7 +14,7 @@ where
 
 `$OPTAWEB_NAME` is a profile name {vehicle-routing|employee-rostering} 
 
-`$PROJECT_SETTINGS` is the settings.xml with the repository which contains ${OPTAPLANNER_BUILD_VERSION} tar.gz 
+`$PROJECT_SETTINGS` is the settings.xml with the repository which contains project dependencies
 
 `$QUICKSTARTS_URL` redhat distribution decision-services-quickstarts.zip url
 
@@ -22,8 +22,7 @@ where
 
 `-Dcontainer.runtime={docker|podman}` change runtime
 
-To set up $PROJECT_SETTINGS file, provide there the mirror repository and npm repository e.g: 
-https://gist.githubusercontent.com/dupliaka/8c65bcbc6eb4eb931ea7124b1daa2228/raw/faa452c141fa1fa247ea724bf0006cf915ac4ad6/settings.xml
+In your $PROJECT_SETTINGS file, you might want to provide the mirror repository and/or proxied npm repository for your environment.
 
 ---------------------------------------
 Issues

--- a/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/pom.xml
+++ b/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build-optaplanner-optawebs-parent</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+    <relativePath>../run-tests-with-build-optaplanner-optawebs-parent</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>run-tests-with-build-kogito-decision-services-quickstarts-optawebs</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-sources-zip</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <url>${kogito.decision.services.quickstarts.url}</url>
+          <unpack>true</unpack>
+          <outputDirectory>${sources.directory}</outputDirectory>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/pom.xml
+++ b/run-tests-with-build-kogito-decision-services-quickstarts-optawebs/pom.xml
@@ -32,6 +32,15 @@
           <outputDirectory>${sources.directory}</outputDirectory>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <pomIncludes>
+            <pomInclude>optaweb-*/${optaweb.artifact.id}/pom.xml</pomInclude>
+          </pomIncludes>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/run-tests-with-build-kogito-decision-services-quickstarts/README.md
+++ b/run-tests-with-build-kogito-decision-services-quickstarts/README.md
@@ -1,0 +1,17 @@
+run-tests-with-build-kogito-decision-services-quickstarts
+---------------------------------------------------------
+
+Run kogito-examples and optaplanner-quickstarst tests delivered as part of decision-services-quickstarts zip
+
+- [kogito-examples](https://github.com/kiegroup/kogito-examples) - just chosen submodules
+- [optaplanner-quickstarts](https://github.com/kiegroup/optaplanner-quickstarts)
+
+Execution
+---------
+The url of the decision-services-quickstarts zip needs to be specified by `-Dkogito.decision.services.quickstarts.url` property.
+
+For running tests in quarkus native mode use  `-Dnative` property.
+
+Note
+----
+Module is under development. Not all tests are executed currently. See the exclusions in the pom.xml.

--- a/run-tests-with-build-kogito-decision-services-quickstarts/pom.xml
+++ b/run-tests-with-build-kogito-decision-services-quickstarts/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>run-tests-with-build-kogito-decision-services-quickstarts</artifactId>
+
+  <properties>
+    <!-- Examples have some Pojos in src/java/main -->
+    <maven.main.skip>false</maven.main.skip>
+    <!-- Fail build if there is any issue in tests. This is passed to maven-invoker-plugin -->
+    <maven.test.failure.ignore>false</maven.test.failure.ignore>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>prepare-sources-zip</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <url>${kogito.decision.services.quickstarts.url}</url>
+          <unpack>true</unpack>
+          <outputDirectory>${sources.directory}</outputDirectory>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <parallelThreads>1</parallelThreads>
+          <profiles>productized</profiles>
+          <pomIncludes>
+            <!-- Use kogito-examples*/pom.xml -->
+            <!-- once https://issues.redhat.com/browse/RHPAM-3649 is resolved -->
+            <pomInclude>kogito-examples*/*/pom.xml</pomInclude>
+
+            <!-- optaplanner-quickstarts blocked completely by https://issues.redhat.com/browse/RHPAM-3649 -->
+            <!--<pomInclude>optaplanner-quickstarts*/*/pom.xml</pomInclude>-->
+          </pomIncludes>
+          <pomExcludes>
+            <!-- https://issues.redhat.com/browse/RHDM-1727 -->
+            <pomExclude>kogito-examples*/dmn-pmml-quarkus-example/pom.xml</pomExclude>
+            <pomExclude>kogito-examples*/dmn-pmml-springboot-example/pom.xml</pomExclude>
+            <pomExclude>kogito-examples*/pmml-quarkus-example/pom.xml</pomExclude>
+            <pomExclude>kogito-examples*/pmml-springboot-example/pom.xml</pomExclude>
+          </pomExcludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-invoker-plugin</artifactId>
+          <configuration>
+            <profiles>
+              <profile>native</profile>
+            </profiles>
+          </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/run-tests-with-build-optaplanner-optawebs-parent/pom.xml
+++ b/run-tests-with-build-optaplanner-optawebs-parent/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>run-tests-with-build</artifactId>
+        <groupId>org.kie</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>run-tests-with-build-optaplanner-optawebs-parent</artifactId>
+    <packaging>pom</packaging>
+
+    <properties>
+        <integration-tests>false</integration-tests>
+        <!-- We can not skip src/main/java module compilation -->
+        <maven.main.skip>false</maven.main.skip>
+        <!-- Fail build if there is any issue in tests. This is passed to maven-invoker-plugin -->
+        <maven.test.failure.ignore>false</maven.test.failure.ignore>
+    </properties>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <configuration>
+                    <parallelThreads>1</parallelThreads>
+                    <pomIncludes>
+                        <pomInclude>**/*/${optaweb.artifact.id}-backend/pom.xml</pomInclude>
+                        <pomInclude>**/*/${optaweb.artifact.id}-standalone/pom.xml</pomInclude>
+                        <pomInclude>**/*/${optaweb.artifact.id}-frontend/pom.xml</pomInclude>
+                    </pomIncludes>
+                    <properties>
+                        <integration-tests>${integration-tests}</integration-tests>
+                        <container.runtime>${container.runtime}</container.runtime>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+    <profiles>
+        <profile>
+            <id>vehicle-routing</id>
+            <activation>
+                <property>
+                    <name>optaweb</name>
+                    <value>vehicle-routing</value>
+                </property>
+            </activation>
+            <properties>
+                <optaweb.artifact.id>optaweb-vehicle-routing</optaweb.artifact.id>
+                <optaweb.group.id>org.optaweb.vehiclerouting</optaweb.group.id>
+            </properties>
+        </profile>
+        <profile>
+            <id>employee-rostering</id>
+            <activation>
+                <property>
+                    <name>optaweb</name>
+                    <value>employee-rostering</value>
+                </property>
+            </activation>
+            <properties>
+                <optaweb.artifact.id>optaweb-employee-rostering</optaweb.artifact.id>
+                <optaweb.group.id>org.optaweb.employeerostering</optaweb.group.id>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/run-tests-with-build-optaplanner-optawebs-parent/pom.xml
+++ b/run-tests-with-build-optaplanner-optawebs-parent/pom.xml
@@ -27,12 +27,8 @@
                 <artifactId>maven-invoker-plugin</artifactId>
                 <configuration>
                     <parallelThreads>1</parallelThreads>
-                    <pomIncludes>
-                        <pomInclude>**/*/${optaweb.artifact.id}-backend/pom.xml</pomInclude>
-                        <pomInclude>**/*/${optaweb.artifact.id}-standalone/pom.xml</pomInclude>
-                        <pomInclude>**/*/${optaweb.artifact.id}-frontend/pom.xml</pomInclude>
-                    </pomIncludes>
                     <properties>
+                        <asciidoctor.skip>false</asciidoctor.skip>
                         <integration-tests>${integration-tests}</integration-tests>
                         <container.runtime>${container.runtime}</container.runtime>
                     </properties>

--- a/run-tests-with-build-optaplanner-optawebs/pom.xml
+++ b/run-tests-with-build-optaplanner-optawebs/pom.xml
@@ -41,6 +41,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-invoker-plugin</artifactId>
+                <configuration>
+                    <pomIncludes>
+                        <pomInclude>${optaweb.artifact.id}*/*/pom.xml</pomInclude>
+                    </pomIncludes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/run-tests-with-build-optaplanner-optawebs/pom.xml
+++ b/run-tests-with-build-optaplanner-optawebs/pom.xml
@@ -3,22 +3,16 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
-        <artifactId>run-tests-with-build</artifactId>
+        <artifactId>run-tests-with-build-optaplanner-optawebs-parent</artifactId>
         <groupId>org.kie</groupId>
         <version>1.0-SNAPSHOT</version>
+        <relativePath>../run-tests-with-build-optaplanner-optawebs-parent</relativePath>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>run-tests-with-build-optaplanner-optawebs</artifactId>
 
-    <properties>
-        <integration-tests>false</integration-tests>
-        <!-- We can not skip src/main/java module compilation -->
-        <maven.main.skip>false</maven.main.skip>
-        <!-- Fail build if there is any issue in tests. This is passed to maven-invoker-plugin -->
-        <maven.test.failure.ignore>false</maven.test.failure.ignore>
-    </properties>
     <build>
         <plugins>
             <plugin>
@@ -47,50 +41,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-invoker-plugin</artifactId>
-                <configuration>
-                    <parallelThreads>1</parallelThreads>
-                    <pomIncludes>
-                        <pomInclude>*/${optaweb.artifact.id}-backend/pom.xml</pomInclude>
-                        <pomInclude>*/${optaweb.artifact.id}-standalone/pom.xml</pomInclude>
-                        <pomInclude>*/${optaweb.artifact.id}-frontend/pom.xml</pomInclude>
-                    </pomIncludes>
-                    <properties>
-                        <integration-tests>${integration-tests}</integration-tests>
-                        <container.runtime>${container.runtime}</container.runtime>
-                    </properties>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>vehicle-routing</id>
-            <activation>
-                <property>
-                    <name>optaweb</name>
-                    <value>vehicle-routing</value>
-                </property>
-            </activation>
-            <properties>
-                <optaweb.artifact.id>optaweb-vehicle-routing</optaweb.artifact.id>
-                <optaweb.group.id>org.optaweb.vehiclerouting</optaweb.group.id>
-            </properties>
-        </profile>
-        <profile>
-            <id>employee-rostering</id>
-            <activation>
-                <property>
-                    <name>optaweb</name>
-                    <value>employee-rostering</value>
-                </property>
-            </activation>
-            <properties>
-                <optaweb.artifact.id>optaweb-employee-rostering</optaweb.artifact.id>
-                <optaweb.group.id>org.optaweb.employeerostering</optaweb.group.id>
-            </properties>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
The added kogito-decision-services-quickstarts module should be used for testing submodules:
- kogito-examples
- optaplanner-quickstarts
    
The added kogito-decision-services-quickstarts-optawebs module should be used for testing submodules:
- optaweb-vehidle-routing
- optaweb-employee-rostering
