### PR TITLE
Incorporate fixes for optawebs stability

### DIFF
--- a/run-tests-with-build-optawebs-parent/README.md
+++ b/run-tests-with-build-optawebs-parent/README.md
@@ -50,6 +50,7 @@ mvn clean verify \
 ### Additional configuration
 * `-Dintegration-tests={true|false}` run integration cypress tests on docker
 * `-Dcontainer.runtime={docker|podman}` change runtime
+* `-Dskip.invoker.tests={true|false}` skip JUnit tests during build of the modules 
 
 ## Module structure
 Each of sub-modules contains configuration for Maven Invoker related settings.

--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/common.sh
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/common.sh
@@ -28,9 +28,13 @@ function wait_for_url() {
   local _increment=1
 
   local _spent=0
-  while [[ "200" != $(curl -LI "${_application_url}" -o /dev/null -w '%{http_code}' -s) && ${_spent} -lt ${_timeout_seconds} ]]
-  do
-    sleep ${_increment}
+  while [[ "200" != $(curl -LI "${_application_url}" -o /dev/null -w '%{http_code}' -s) ]]; do
+    if [[ "${_spent}" -eq "${_timeout_seconds}" ]]; then
+      echo "Timeout ${_application_url} is not reachable"
+      store_logs_from_pods "target"
+      exit 1
+    fi
+    sleep "${_increment}"
     _spent=$((_spent + _increment))
     echo "Waiting for ${_spent} seconds for ${_application_url} to become available."
   done
@@ -39,8 +43,7 @@ function wait_for_url() {
 # Stores logs from all pods in the project
 function store_logs_from_pods() {
   local _target_directory=$1
-  for pod in $(oc get pods -o name)
-  do
+  for pod in $(oc get pods -o name); do
     sanitized_pod=${pod#"pod/"}
     oc logs "${sanitized_pod}" > "${_target_directory}/${sanitized_pod}.log"
   done

--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-employee-rostering-test-script-openshift.sh
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-employee-rostering-test-script-openshift.sh
@@ -53,7 +53,7 @@ chmod u+x "${project_basedir}"/runOnOpenShift.sh
 # pass settings file and skip enforcer to be able to test artifacts from bxms-qe
 sed -i 's#mvn clean install -DskipTests -Dquarkus.profile=postgres#mvn clean install -DskipTests -Dquarkus.profile=postgres -Denforcer.skip -s '$settings_file'#g' "${project_basedir}"/runOnOpenShift.sh
 # increase possible postgresql memory consumption
-sed -i 's/oc new-app --name postgresql postgresql-persistent/oc new-app --name postgresql postgresql-persistent -p MAX_MEMORY=2GiB/' "${project_basedir}"/runOnOpenShift.sh
+sed -i 's/oc new-app --name postgresql postgresql-persistent/oc new-app --name postgresql postgresql-persistent -p MEMORY_LIMIT=2Gi/' "${project_basedir}"/runOnOpenShift.sh
 
 readonly frontend_directory=$(find "${project_basedir}" -maxdepth 1 -name "*frontend")
 [[ -d ${frontend_directory} ]] || {

--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-employee-rostering-test-script-openshift.sh
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-employee-rostering-test-script-openshift.sh
@@ -18,14 +18,14 @@ function display_help() {
   echo "  ${script_name} --help"
 }
 
-if [[ $1 == "--help" ]]
+if [[ "$1" == "--help" ]]
 then
   display_help
   exit 0
 fi
 
 readonly project_basedir=$1
-[[ -d ${project_basedir} ]] || {
+[[ -d "${project_basedir}" ]] || {
   echo "Project base directory $project_basedir does not exist!"
   display_help
   exit 1
@@ -36,7 +36,7 @@ readonly openshift_api_url=$3
 readonly openshift_user=$4
 readonly openshift_password=$5
 readonly settings_file=$6
-readonly container_runtime=$7
+readonly container_engine=$7
 
 oc login -u "${openshift_user}" -p "${openshift_password}" "${openshift_api_url}" --insecure-skip-tls-verify=true
 
@@ -50,21 +50,37 @@ oc get project "${openshift_project}"
 
 chmod u+x "${project_basedir}"/runOnOpenShift.sh
 
-sed 's#mvn clean install -DskipTests -Dquarkus.profile=postgres#mvn clean install -DskipTests -Dquarkus.profile=postgres -Denforcer.skip -s '$settings_file'#g' "${project_basedir}"/runOnOpenShift.sh
+# pass settings file and skip enforcer to be able to test artifacts from bxms-qe
 sed -i 's#mvn clean install -DskipTests -Dquarkus.profile=postgres#mvn clean install -DskipTests -Dquarkus.profile=postgres -Denforcer.skip -s '$settings_file'#g' "${project_basedir}"/runOnOpenShift.sh
-
-
-yes | "${project_basedir}"/runOnOpenShift.sh || {
-  echo "runOnOpenShift.sh failed!"
-  echo "Saving logs and exiting."
-  store_logs_from_pods "target"
-  exit 1
-}
+# increase possible postgresql memory consumption
+sed -i 's/oc new-app --name postgresql postgresql-persistent/oc new-app --name postgresql postgresql-persistent -p MAX_MEMORY=2GiB/' "${project_basedir}"/runOnOpenShift.sh
 
 readonly frontend_directory=$(find "${project_basedir}" -maxdepth 1 -name "*frontend")
 [[ -d ${frontend_directory} ]] || {
   echo "No frontend module was found in ${project_basedir} as ${frontend_directory}!"
   display_help
+  exit 1
+}
+
+# replace image by digest so openshift doesn't download new image, avoids docker pulling limitation
+# additionally edit mirror configuration on the Openshift
+sed -i 's;FROM docker.io/library/nginx:1.17.5;FROM docker.io/library/nginx@sha256:922c815aa4df050d4df476e92daed4231f466acc8ee90e0e774951b0fd7195a4;' "${frontend_directory}/docker/Dockerfile"
+
+readonly standalone_directory=$(find "${project_basedir}" -maxdepth 1 -name "*standalone")
+[[ -d ${standalone_directory} ]] || {
+  echo "No standalone module was found in ${project_basedir} as ${standalone_directory}!"
+  display_help
+  exit 1
+}
+
+# replace image by digest so openshift doesn't download new image, avoids docker pulling limitation
+# additionally edit mirror configuration on the Openshift
+sed -i 's;FROM adoptopenjdk/openjdk11:ubi-minimal;FROM adoptopenjdk/openjdk11@sha256:081cbb525cd6ed4c0c14048973fa80422ba89cdb87893a255270b03d6e5294d3;' "${standalone_directory}/Dockerfile"
+
+yes | "${project_basedir}"/runOnOpenShift.sh || {
+  echo "runOnOpenShift.sh failed!"
+  echo "Saving logs and exiting."
+  store_logs_from_pods "target"
   exit 1
 }
 
@@ -74,7 +90,7 @@ wait_for_url "${application_url}" 60
 
 # run the cypress test
 readonly cypress_image_version=$2
-run_cypress "${application_url}" "${frontend_directory}" "${cypress_image_version}" "${container_runtime}"
+run_cypress "${application_url}" "${frontend_directory}" "${cypress_image_version}" "${container_engine}"
 
 # store logs from all pods in the project
 store_logs_from_pods "target"

--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-vehicle-routing-test-script-openshift.sh
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-vehicle-routing-test-script-openshift.sh
@@ -14,7 +14,7 @@ function display_help() {
 
   echo "This script tests deployment of Optaweb Vehicle Routing on OpenShift."
   echo "Usage:"
-  echo "  ${script_name} PROJECT_BASEDIR CYPRESS_IMAGE_VERSION OPENSHIFT_API_URL OPENSHIFT_USER OPENSHIFT_PASSWORD"
+  echo "  ${script_name} PROJECT_BASEDIR CYPRESS_IMAGE_VERSION"
   echo "  ${script_name} --help"
 }
 
@@ -38,6 +38,8 @@ readonly test_osm_data_url="https://github.com/kiegroup/optaweb-vehicle-routing/
 readonly openshift_api_url=$3
 readonly openshift_user=$4
 readonly openshift_password=$5
+readonly settings_file=$6
+readonly container_engine=$7
 
 oc login -u "${openshift_user}" -p "${openshift_password}" "${openshift_api_url}" --insecure-skip-tls-verify=true
 
@@ -51,13 +53,6 @@ oc get project "${openshift_project}"
 
 chmod u+x "${project_basedir}"/runOnOpenShift.sh
 
-yes | "${project_basedir}"/runOnOpenShift.sh test.osm.pbf DE "${test_osm_data_url}" || {
-  echo "runOnOpenShift.sh failed!"
-  echo "Saving logs and exiting."
-  store_logs_from_pods "target"
-  exit 1
-}
-
 readonly frontend_directory=$(find "${project_basedir}" -maxdepth 1 -name "*frontend")
 [[ -d ${frontend_directory} ]] || {
   echo "No frontend module was found in ${project_basedir} as ${frontend_directory}!"
@@ -65,13 +60,25 @@ readonly frontend_directory=$(find "${project_basedir}" -maxdepth 1 -name "*fron
   exit 1
 }
 
+# replace image by digest so openshift doesn't download new image, avoids docker pulling limitation
+# additionally edit mirror configuration on the Openshift
+sed -i 's;FROM docker.io/library/nginx:1.17.5;FROM docker.io/library/nginx@sha256:922c815aa4df050d4df476e92daed4231f466acc8ee90e0e774951b0fd7195a4;' "${frontend_directory}/docker/Dockerfile"
+
+yes | "${project_basedir}"/runOnOpenShift.sh test.osm.pbf DE "${test_osm_data_url}" || {
+  echo "runOnOpenShift.sh failed!"
+  echo "Saving logs and exiting."
+  store_logs_from_pods "target"
+  exit 1
+}
+
+
 readonly application_url="http://$(oc get route frontend -o custom-columns=:spec.host | tr -d '\n')"
 # wait for the application to become available
 wait_for_url "${application_url}" 60
 
 # run the cypress test
 readonly cypress_image_version=$2
-run_cypress "${application_url}" "${frontend_directory}" "${cypress_image_version}"
+run_cypress "${application_url}" "${frontend_directory}" "${cypress_image_version}" "${container_engine}"
 
 # store logs from pods in the target folder
 store_logs_from_pods "target"

--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/pom.xml
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/pom.xml
@@ -19,7 +19,6 @@
         <openshift.password>developer</openshift.password>
         <version.cypress.docker>3.6.0</version.cypress.docker>
         <container.runtime>podman</container.runtime>
-        <skip.component.tests>false</skip.component.tests>
     </properties>
 
     <dependencies>
@@ -61,9 +60,6 @@
                 <artifactId>maven-invoker-plugin</artifactId>
                 <configuration>
                     <parallelThreads>1</parallelThreads>
-                    <properties>
-                        <maven.test.skip>${skip.component.tests}</maven.test.skip>
-                    </properties>
                     <!--
                     script deciding if included project is:
                       executed (either script missing or returning true)
@@ -87,10 +83,10 @@
         <profile>
             <id>openshift</id>
             <properties>
+                <skip.invoker.tests>${skipTests}</skip.invoker.tests>
                 <!-- Relying on profile activation property from run-tests-with-build-project-sources-dependency-get module.
                 Enforcer of that module assures that the value is set properly.-->
                 <optaweb.project.name>${project.sources.artifact}</optaweb.project.name>
-                <skip.component.tests>true</skip.component.tests>
             </properties>
             <activation>
                 <property>

--- a/run-tests-with-build-optawebs-parent/pom.xml
+++ b/run-tests-with-build-optawebs-parent/pom.xml
@@ -21,6 +21,7 @@
         <!-- just for enforcer activation section of profiles does not interpolate properties -->
         <activation.property.name>test.type</activation.property.name>
         <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.quickstarts.zip})$</enforcer.regex.activation.property>
+        <skip.invoker.tests>false</skip.invoker.tests>
     </properties>
     <build>
         <plugins>
@@ -57,6 +58,7 @@
                     <configuration>
                         <parallelThreads>1</parallelThreads>
                         <properties>
+                            <skipTests>${skip.invoker.tests}</skipTests>
                             <asciidoctor.skip>false</asciidoctor.skip>
                             <integration-tests>${integration-tests}</integration-tests>
                             <container.runtime>${container.runtime}</container.runtime>


### PR DESCRIPTION
Fail fast if the back end is not reachable after deployment

Pull images by digest to avoid docker limits - by using mirrors
Add container engine configuration

Add skip test parameter to property of the parent invoker (in other case it gets overwritten)