### PR TITLE
update kogito-runtimes modules after KOGITO-5712

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
     <!--TODO - settings.xml-->
     <main.basedir>${maven.multiModuleProjectDirectory}</main.basedir>
     <settings.xml.file>${main.basedir}/settings/settings.xml</settings.xml.file>
-    <invoker.settings.xml.file>${session.request.userSettingsFile.path}</invoker.settings.xml.file>
 
     <!-- Property where invoker expects the sources to be downloaded into -->
     <sources.directory>${project.build.directory}/sources/</sources.directory>
@@ -162,7 +161,6 @@
             <mergeUserSettings>true</mergeUserSettings>
             <mavenOpts>-Xms1g -Xmx3g</mavenOpts>
             <parallelThreads>2</parallelThreads>
-            <settingsFile>${invoker.settings.xml.file}</settingsFile>
             <properties>
               <!-- maven-compiler-plugin properties -->
               <maven.main.skip>${maven.main.skip}</maven.main.skip>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
@@ -12,6 +12,14 @@
 
   <artifactId>kogito-runtimes-project-sources-test</artifactId>
 
+  <properties>
+    <!--
+      Ideally just -Dproductized should be here, the excluded modules lack some dependencies that are not yet productized,
+      thus unavailable in productized build as (not only) test dependencies.
+    -->
+    <maven.modules.resolution.reactor.filtering>-Dproductized -pl -:kogito-addons-springboot-rest-exception-handler,-:kogito-addons-springboot-process-svg,-:kogito-addons-springboot-process-management,-:kogito-addons-springboot-task-management,-:kogito-addons-quarkus-process-svg,-:kogito-addons-quarkus-rest-exception-handler,-:kogito-addons-quarkus-process-management,-:kogito-addons-quarkus-task-management,-:integration-tests-quarkus-processes,-:integration-tests-springboot,-:integration-tests-kogito-plugin</maven.modules.resolution.reactor.filtering>
+  </properties>
+
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
@@ -68,43 +76,6 @@
               </pomIncludes>
               <pomExcludes>
                 <!-- Excludes work still as expected. -->
-              </pomExcludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>install-integration-tests-parent-before-invocation</id>
-            <phase>test</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <!-- path relative to the poms included below -->
-              <invokerPropertiesFile>../../invoker.properties</invokerPropertiesFile>
-              <goals>
-                <goal>clean install --non-recursive</goal>
-              </goals>
-              <pomIncludes>
-                <pomInclude>kogito-runtimes*/integration-tests/pom.xml</pomInclude>
-              </pomIncludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>run-explicitly-integration-tests</id>
-            <phase>test</phase>
-            <goals>
-              <goal>install</goal>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <!-- path relative to the poms included below -->
-              <invokerPropertiesFile>../../../invoker.properties</invokerPropertiesFile>
-              <pomIncludes>
-                <pomInclude>kogito-runtimes*/integration-tests/*/pom.xml</pomInclude>
-              </pomIncludes>
-              <pomExcludes>
-                <pomExclude>**/integration-tests-quarkus-processes/pom.xml</pomExclude>
-                <pomExclude>**/integration-tests-springboot/pom.xml</pomExclude>
-                <pomExclude>**/integration-tests-kogito-plugin/pom.xml</pomExclude>
               </pomExcludes>
             </configuration>
           </execution>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
@@ -43,6 +43,10 @@
           <execution>
             <id>run-tests</id>
             <configuration>
+              <goals>
+                <goal>clean</goal>
+                <goal>install</goal> <!-- ok to install, will build full project from parent - all is taken from reactor anyway -->
+              </goals>
               <properties>
                 <productized>true</productized>
               </properties>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
@@ -53,43 +53,6 @@
               </pomIncludes>
             </configuration>
           </execution>
-          <execution>
-            <id>install-integration-tests-parent-before-invocation</id>
-            <phase>test</phase>
-            <goals>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <!-- path relative to the poms included below -->
-              <invokerPropertiesFile>../../../invoker.properties</invokerPropertiesFile>
-              <goals>
-                <goal>clean install --non-recursive</goal>
-              </goals>
-              <pomIncludes>
-                <pomInclude>kogito-*/*kogito-runtimes*/integration-tests/pom.xml</pomInclude>
-              </pomIncludes>
-            </configuration>
-          </execution>
-          <execution>
-            <id>run-explicitly-integration-tests</id>
-            <phase>test</phase>
-            <goals>
-              <goal>install</goal>
-              <goal>run</goal>
-            </goals>
-            <configuration>
-              <!-- path relative to the poms included below -->
-              <invokerPropertiesFile>../../../../invoker.properties</invokerPropertiesFile>
-              <pomIncludes>
-                <pomInclude>kogito-*/*kogito-runtimes*/integration-tests/*/pom.xml</pomInclude>
-              </pomIncludes>
-              <pomExcludes>
-                <pomExclude>**/integration-tests-quarkus-processes/pom.xml</pomExclude>
-                <pomExclude>**/integration-tests-springboot/pom.xml</pomExclude>
-                <pomExclude>**/integration-tests-kogito-plugin/pom.xml</pomExclude>
-              </pomExcludes>
-            </configuration>
-          </execution>
         </executions>
       </plugin>
     </plugins>

--- a/scripts/resolve-includes.groovy
+++ b/scripts/resolve-includes.groovy
@@ -121,7 +121,7 @@ private String getMvnCommand() {
     if (mavenReactorFiltering) {
         mvnCommandToRun = mvnCommandToRun + " $mavenReactorFiltering"
     }
-    if (mavenRepoLocal && Files.exists(Path.of(mavenRepoLocal))) {
+    if (mavenRepoLocal) {
         mvnCommandToRun = mvnCommandToRun + " -Dmaven.repo.local=$mavenRepoLocal"
     }
     if (mavenSettings && Files.exists(Path.of(mavenSettings))) {


### PR DESCRIPTION
* Remove explicit execution of integration-tests (those are now part of `productized` profile, so are included out of the box).
* Fix settings.xml handling - passing `${session.request.userSettingsFile.path}` to invoker through `settingsFile` causes issues due to non-expanded system properties (nexus.group, nexus.host, etc). Reason is that by default system properties are not passed from parent maven build to invoker, thus are not available. Retracting from this approach, invoker by default uses `${settings}` value imported, which means that invoker shares what is passed to maven build via `-s`. This is enough in our case and no explicit passing of settingsFile is needed at all. (Applies just to maven-invoker-plugin, any other means of running mvn builds might require using the `${session.request.userSettingsFile.path}` - like using invoker from Java code, or explicitly running mvn commands from groovy or java code.)
* Fixing a bug in resolve-includes.groovy - `maven.repo.local` directory does not need to exist before the mvn run (will be created during runtime).