### PR TITLE
BAQE-865 - Move Drools database community tests suite to new Mavenized repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <module>run-tests-with-build-camel-container</module>
     <module>run-tests-with-build-integration</module>
     <module>run-tests-with-build-business-central-community</module>
+    <module>run-tests-with-build-drools-db</module>
     <!-- Not a module on purpose, invoke using -f or from that folder:
     <module>run-tests-with-build-sources-zip-download</module>
     <module>run-tests-with-build-project-sources-dependency-get</module>

--- a/run-tests-with-build-drools-db/pom.xml
+++ b/run-tests-with-build-drools-db/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>run-tests-with-build-drools-db</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>checkout-drools</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>checkout</goal>
+            </goals>
+            <configuration>
+              <connectionUrl>scm:git:${drools.repo.url}</connectionUrl>
+              <checkoutDirectory>${sources.directory}/drools</checkoutDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.kie</groupId>
+        <artifactId>unpack-build-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>download-build-jars</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack-build</goal>
+            </goals>
+            <configuration>
+              <excludeDirectories combine.children="append">
+                <excludeDirectory>.*drools-impact.*</excludeDirectory>
+                <excludeDirectory>.*test-integration-nomvel.*</excludeDirectory>
+              </excludeDirectories>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <pomIncludes>
+            <pomInclude>drools/drools-persistence/pom.xml</pomInclude>
+          </pomIncludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>


### PR DESCRIPTION
Added the module "run-tests-with-build-drools-db" to execute drools-persistence tests.