### PR TITLE
use fail-at-end invoker.failureBehavior

### DIFF
--- a/config-files/invoker.properties
+++ b/config-files/invoker.properties
@@ -1,1 +1,1 @@
-invoker.failureBehavior = fail-never
+invoker.failureBehavior = fail-at-end


### PR DESCRIPTION
The fail-never policy hides build failures in case of missing deps, etc.