### PR TITLE
Update cypress version for openshift integration tests 

### DIFF
--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/pom.xml
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/pom.xml
@@ -17,7 +17,7 @@
         <openshift.api-url>https://api.crc.testing:6443</openshift.api-url>
         <openshift.user>developer</openshift.user>
         <openshift.password>developer</openshift.password>
-        <version.cypress.docker>3.6.0</version.cypress.docker>
+        <version.cypress.docker>7.0.1</version.cypress.docker>
         <container.runtime>podman</container.runtime>
     </properties>
 


### PR DESCRIPTION
Cypress test belongs to the community optaweb
The cypress version which get used there changed
The script that launches cypress tests on openshift runs it with shell adding another profile in optaweb community will pollute the pom's simplicity

The changes from main
 https://github.com/kiegroup/run-tests-with-build/pull/42