### PR TITLE
Remove unused property kogito.examples.repo.url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,6 @@
     <jbpm.wb.repo.url>${git.server.url}/jbpm-wb</jbpm.wb.repo.url>
     <kie.wb.common.repo.url>${git.server.url}/kie-wb-common</kie.wb.common.repo.url>
     <optaplanner.wb.repo.url>${git.server.url}/optaplanner-wb</optaplanner.wb.repo.url>
-    <kogito.examples.repo.url>${git.server.url}/kogito-examples</kogito.examples.repo.url>
     <kogito.editors.java.repo.url>${git.server.url}/kogito-editors-java</kogito.editors.java.repo.url>
 
     <!-- Properties used by source-downloading modules (*-project-sources-dependency-get, *-sources-zip-download) -->


### PR DESCRIPTION
The command `grep -ri kogito.examples.repo.url` returns single occurence, this I think we can remove this property. I spotted this during https://github.com/kiegroup/run-tests-with-build/pull/44/files review, where similar property was introduced `kogito.editors.java.repo.url`. So I wanted to check consistency we use similar property in simalr way, but found out we do not use that property at all.