### PR TITLE
BAQE-2212 Update kogito-editors-java tests execution after migration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <module>run-tests-with-build-integration</module>
     <module>run-tests-with-build-business-central-community</module>
     <module>run-tests-with-build-drools-db</module>
-    <module>run-tests-with-build-kogito-editors-java</module>
+    <module>run-tests-with-build-kogito-tooling-stunner-editors</module>
     <!-- Not a module on purpose, invoke using -f or from that folder:
     <module>run-tests-with-build-sources-zip-download</module>
     <module>run-tests-with-build-project-sources-dependency-get</module>
@@ -95,7 +95,7 @@
     <jbpm.wb.repo.url>${git.server.url}/jbpm-wb</jbpm.wb.repo.url>
     <kie.wb.common.repo.url>${git.server.url}/kie-wb-common</kie.wb.common.repo.url>
     <optaplanner.wb.repo.url>${git.server.url}/optaplanner-wb</optaplanner.wb.repo.url>
-    <kogito.editors.java.repo.url>${git.server.url}/kogito-editors-java</kogito.editors.java.repo.url>
+    <kogito.tooling.repo.url>${git.server.url}/kogito-tooling</kogito.tooling.repo.url>
 
     <!-- Properties used by source-downloading modules (*-project-sources-dependency-get, *-sources-zip-download) -->
     <download.sources.url></download.sources.url> <!-- keep empty to be able to check by enforcer -->

--- a/run-tests-with-build-kogito-tooling-stunner-editors/pom.xml
+++ b/run-tests-with-build-kogito-tooling-stunner-editors/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
-  <artifactId>run-tests-with-build-kogito-editors-java</artifactId>
+  <artifactId>run-tests-with-build-kogito-tooling-stunner-editors</artifactId>
 
   <build>
     <plugins>
@@ -44,14 +44,14 @@
         </configuration>
         <executions>
           <execution>
-            <id>checkout-kogito-editors-java</id>
+            <id>checkout-kogito-tooling</id>
             <phase>generate-sources</phase>
             <goals>
               <goal>checkout</goal>
             </goals>
             <configuration>
-              <connectionUrl>scm:git:${kogito.editors.java.repo.url}</connectionUrl>
-              <checkoutDirectory>${sources.directory}/kogito-editors-java</checkoutDirectory>
+              <connectionUrl>scm:git:${kogito.tooling.repo.url}</connectionUrl>
+              <checkoutDirectory>${sources.directory}/kogito-tooling</checkoutDirectory>
             </configuration>
           </execution>
         </executions>
@@ -61,7 +61,7 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <pomIncludes>
-            <pomInclude>kogito-editors-java/pom.xml</pomInclude>
+            <pomInclude>kogito-tooling/packages/stunner-editors/pom.xml</pomInclude>
           </pomIncludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Now it invokes the same teste, but from kogito-tooling repository
stunner-editors package.