### PR TITLE
Add native for quickstarts and optaplanner quarkus integration

### DIFF
--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-project-sources-test/pom.xml
@@ -17,7 +17,7 @@
     <quarkus.profile></quarkus.profile>
     <quarkus.native.container-build>true</quarkus.native.container-build>
     <quarkus.native.container-runtime>docker</quarkus.native.container-runtime>
-    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.1-java11</quarkus.native.builder-image>
+    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
   </properties>
 
   <dependencies>

--- a/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>run-tests-with-build-optaplanner-parent</artifactId>
@@ -11,6 +11,9 @@
   <packaging>pom</packaging>
 
   <artifactId>optaplanner-project-sources-test</artifactId>
+  <properties>
+    <invoker.pom.include>**/pom.xml</invoker.pom.include>
+  </properties>
 
   <dependencies>
     <!-- define as dependency to assure reactor order -->
@@ -61,7 +64,7 @@
             <!-- includes everything, filtering is done in resolve-includes.groovy script
             which adds invoker-run.groovy script containing 'return false' near each pom.xml
             that should be excluded.-->
-            <pomInclude>**/pom.xml</pomInclude>
+            <include>${invoker.pom.include}</include>
           </pomIncludes>
           <pomExcludes>
             <!-- Excludes work still as expected. -->
@@ -70,4 +73,37 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- native builds make sense just for quarkus examples -->
+        <invoker.pom.include>**/optaplanner-quarkus-integration/*/integration-test/pom.xml</invoker.pom.include>
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-invoker-plugin</artifactId>
+              <configuration>
+                <properties combine.children="append">
+                  <native>true</native>
+                  <quarkus.profile>${quarkus.profile}</quarkus.profile>
+                  <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
+                  <quarkus.native.container-runtime>${quarkus.native.container-runtime}</quarkus.native.container-runtime>
+                  <quarkus.native.builder-image>${quarkus.native.builder-image}</quarkus.native.builder-image>
+                </properties>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
@@ -13,6 +13,10 @@
   <artifactId>optaplanner-project-sources-test</artifactId>
   <properties>
     <invoker.pom.include>**/pom.xml</invoker.pom.include>
+    <quarkus.profile></quarkus.profile>
+    <quarkus.native.container-build>true</quarkus.native.container-build>
+    <quarkus.native.container-runtime>docker</quarkus.native.container-runtime>
+    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
   </properties>
 
   <dependencies>

--- a/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
@@ -39,40 +39,14 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
-      <plugin>
-        <groupId>org.codehaus.gmavenplus</groupId>
-        <artifactId>gmavenplus-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>resolve-includes</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
-          <!--
-          script deciding if included project is:
-            executed (either script missing or returning true)
-              or
-            skipped (when returns false or throws error) -->
-          <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
           <pomIncludes>
-            <!-- includes everything, filtering is done in resolve-includes.groovy script
-            which adds invoker-run.groovy script containing 'return false' near each pom.xml
-            that should be excluded.-->
             <include>${invoker.pom.include}</include>
           </pomIncludes>
-          <pomExcludes>
-            <!-- Excludes work still as expected. -->
-          </pomExcludes>
         </configuration>
       </plugin>
     </plugins>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -59,43 +59,23 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
+          <!--
+          script deciding if included project is:
+            executed (either script missing or returning true)
+              or
+            skipped (when returns false or throws error) -->
+          <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
+          <pomIncludes>
+            <include>${invoker.pom.include}</include>
+          </pomIncludes>
+          <pomExcludes>
+            <!-- Excludes work still as expected. -->
+          </pomExcludes>
         </configuration>
       </plugin>
     </plugins>
   </build>
   <profiles>
-    <profile>
-      <id>non-native</id>
-      <activation>
-        <property>
-          <name>!native</name>
-        </property>
-      </activation>
-      <build>
-        <pluginManagement>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-invoker-plugin</artifactId>
-              <configuration>
-                <!--
-                script deciding if included project is:
-                  executed (either script missing or returning true)
-                    or
-                  skipped (when returns false or throws error) -->
-                <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
-                <pomIncludes>
-                  <include>${invoker.pom.include}</include>
-                </pomIncludes>
-                <pomExcludes>
-                  <!-- Excludes work still as expected. -->
-                </pomExcludes>
-              </configuration>
-            </plugin>
-          </plugins>
-        </pluginManagement>
-      </build>
-    </profile>
     <profile>
       <id>native</id>
       <activation>
@@ -104,7 +84,6 @@
         </property>
       </activation>
       <build>
-        <pluginManagement>
           <plugins>
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
@@ -125,7 +104,6 @@
               </configuration>
             </plugin>
           </plugins>
-        </pluginManagement>
       </build>
     </profile>
   </profiles>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -45,11 +45,6 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
-          <!--
-          script deciding if included project is:
-            executed (either script missing or returning true)
-              or
-            skipped (when returns false or throws error) -->
           <pomIncludes>
             <include>${invoker.pom.include}</include>
           </pomIncludes>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -12,6 +12,14 @@
 
   <artifactId>optaplanner-quickstarts-project-sources-test</artifactId>
 
+  <properties>
+    <invoker.pom.include>**/pom.xml</invoker.pom.include>
+    <quarkus.profile></quarkus.profile>
+    <quarkus.native.container-build>true</quarkus.native.container-build>
+    <quarkus.native.container-runtime>docker</quarkus.native.container-runtime>
+    <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
+  </properties>
+
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
@@ -51,23 +59,78 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
-          <!--
-          script deciding if included project is:
-            executed (either script missing or returning true)
-              or
-            skipped (when returns false or throws error) -->
-          <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
-          <pomIncludes>
-            <!-- includes everything, filtering is done in resolve-includes.groovy script
-            which adds invoker-run.groovy script containing 'return false' near each pom.xml
-            that should be excluded.-->
-            <pomInclude>**/pom.xml</pomInclude>
-          </pomIncludes>
-          <pomExcludes>
-            <!-- Excludes work still as expected. -->
-          </pomExcludes>
         </configuration>
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>non-native</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-invoker-plugin</artifactId>
+              <configuration>
+                <properties combine.children="append">
+                  <skipTests>true</skipTests>
+                </properties>
+                <!--
+                script deciding if included project is:
+                  executed (either script missing or returning true)
+                    or
+                  skipped (when returns false or throws error) -->
+                <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
+                <pomIncludes>
+                  <include>${invoker.pom.include}</include>
+                </pomIncludes>
+                <pomExcludes>
+                  <!-- Excludes work still as expected. -->
+                </pomExcludes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+    <profile>
+      <id>native</id>
+      <activation>
+        <property>
+          <name>native</name>
+        </property>
+      </activation>
+      <properties>
+        <!-- native builds make sense just for quarkus examples -->
+      </properties>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-invoker-plugin</artifactId>
+              <configuration>
+                <properties combine.children="append">
+                  <native>true</native>
+                  <quarkus.profile>${quarkus.profile}</quarkus.profile>
+                  <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
+                  <quarkus.native.container-runtime>${quarkus.native.container-runtime}</quarkus.native.container-runtime>
+                  <quarkus.native.builder-image>${quarkus.native.builder-image}</quarkus.native.builder-image>
+                </properties>
+                <pomIncludes>
+                  <include>**/technology/kotlin-quarkus/pom.xml</include>
+                  <include>**/technology/java-activemq-quarkus/pom.xml</include>
+                  <include>**/use-cases/*/pom.xml</include>
+                </pomIncludes>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -15,7 +15,6 @@
   <properties>
     <invoker.pom.include>**/pom.xml</invoker.pom.include>
     <quarkus.profile></quarkus.profile>
-    <maven.modules.resolution.selector.script.name></maven.modules.resolution.selector.script.name>
     <quarkus.native.container-build>true</quarkus.native.container-build>
     <quarkus.native.container-runtime>docker</quarkus.native.container-runtime>
     <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
@@ -51,7 +50,6 @@
             executed (either script missing or returning true)
               or
             skipped (when returns false or throws error) -->
-          <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
           <pomIncludes>
             <include>${invoker.pom.include}</include>
           </pomIncludes>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -67,7 +67,9 @@
     <profile>
       <id>non-native</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!native</name>
+        </property>
       </activation>
       <build>
         <pluginManagement>
@@ -76,9 +78,6 @@
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-invoker-plugin</artifactId>
               <configuration>
-                <properties combine.children="append">
-                  <skipTests>true</skipTests>
-                </properties>
                 <!--
                 script deciding if included project is:
                   executed (either script missing or returning true)

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -40,20 +40,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
-      <plugin>
-        <groupId>org.codehaus.gmavenplus</groupId>
-        <artifactId>gmavenplus-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>resolve-includes</id>
-            <phase>generate-resources</phase>
-            <goals>
-              <goal>execute</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
@@ -85,19 +71,6 @@
       </activation>
       <build>
         <plugins>
-          <plugin>
-            <groupId>org.codehaus.gmavenplus</groupId>
-            <artifactId>gmavenplus-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>resolve-includes</id>
-                <phase>none</phase>
-                <goals>
-                  <goal>execute</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-invoker-plugin</artifactId>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -15,6 +15,7 @@
   <properties>
     <invoker.pom.include>**/pom.xml</invoker.pom.include>
     <quarkus.profile></quarkus.profile>
+    <maven.modules.resolution.selector.script.name></maven.modules.resolution.selector.script.name>
     <quarkus.native.container-build>true</quarkus.native.container-build>
     <quarkus.native.container-runtime>docker</quarkus.native.container-runtime>
     <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -104,9 +104,6 @@
           <name>native</name>
         </property>
       </activation>
-      <properties>
-        <!-- native builds make sense just for quarkus examples -->
-      </properties>
       <build>
         <pluginManagement>
           <plugins>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-project-sources-test/pom.xml
@@ -84,26 +84,40 @@
         </property>
       </activation>
       <build>
-          <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-invoker-plugin</artifactId>
-              <configuration>
-                <properties combine.children="append">
-                  <native>true</native>
-                  <quarkus.profile>${quarkus.profile}</quarkus.profile>
-                  <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
-                  <quarkus.native.container-runtime>${quarkus.native.container-runtime}</quarkus.native.container-runtime>
-                  <quarkus.native.builder-image>${quarkus.native.builder-image}</quarkus.native.builder-image>
-                </properties>
-                <pomIncludes>
-                  <include>**/technology/kotlin-quarkus/pom.xml</include>
-                  <include>**/technology/java-activemq-quarkus/pom.xml</include>
-                  <include>**/use-cases/*/pom.xml</include>
-                </pomIncludes>
-              </configuration>
-            </plugin>
-          </plugins>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>resolve-includes</id>
+                <phase>none</phase>
+                <goals>
+                  <goal>execute</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <configuration>
+              <properties combine.children="append">
+                <native>true</native>
+                <quarkus.profile>${quarkus.profile}</quarkus.profile>
+                <quarkus.native.container-build>${quarkus.native.container-build}</quarkus.native.container-build>
+                <quarkus.native.container-runtime>${quarkus.native.container-runtime}</quarkus.native.container-runtime>
+                <quarkus.native.builder-image>${quarkus.native.builder-image}</quarkus.native.builder-image>
+              </properties>
+              <pomExcludes>
+                <exclude>pom.xml</exclude>
+                <exclude>*/build/quickstarts-showcase/pom.xml</exclude>
+                <exclude>*/technology/java-spring-boot/pom.xml</exclude>
+                <exclude>*/hello-world/pom.xml</exclude>
+              </pomExcludes>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/pom.xml
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/pom.xml
@@ -41,40 +41,14 @@
                     </execution>
                 </executions>
             </plugin>
-            <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
-            <plugin>
-                <groupId>org.codehaus.gmavenplus</groupId>
-                <artifactId>gmavenplus-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resolve-includes</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>execute</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
                 <configuration>
                     <parallelThreads>1</parallelThreads>
-                    <!--
-                    script deciding if included project is:
-                      executed (either script missing or returning true)
-                        or
-                      skipped (when returns false or throws error) -->
-                    <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
                     <pomIncludes>
-                        <!-- includes everything, filtering is done in resolve-includes.groovy script
-                        which adds invoker-run.groovy script containing 'return false' near each pom.xml
-                        that should be excluded.-->
                         <pomInclude>**/pom.xml</pomInclude>
                     </pomIncludes>
-                    <pomExcludes>
-                        <!-- Excludes work still as expected. -->
-                    </pomExcludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Quickstarts are collected in different places of the artifact repository since the pojects are completely undependent I decide to get rid of filtering. Also I added non-native so to not append pomincludes together in case of poms located in different folders

Optaplanner profiles is just the same as in kogito.