### PR TITLE
Return filtering to avoid testing full profile

### DIFF
--- a/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
@@ -39,11 +39,31 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>resolve-includes</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
+          <!--
+          script deciding if included project is:
+            executed (either script missing or returning true)
+              or
+            skipped (when returns false or throws error) -->
+          <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
           <pomIncludes>
             <include>${invoker.pom.include}</include>
           </pomIncludes>


### PR DESCRIPTION
optaplanner-parent has docs folder that contains ascidoctor files which we skip in this certification if skip filtering it will not be able to deliver index.pdf which we need while building uberjar