### PR TITLE
Quarkus platform testing changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,9 @@
     <enforcer.test.type.sources.zip>sources-zip</enforcer.test.type.sources.zip>
     <enforcer.test.type.quickstarts.zip>quickstarts-zip</enforcer.test.type.quickstarts.zip>
     <enforcer.test.type.scm.checkout>scm-checkout</enforcer.test.type.scm.checkout>
+
+    <!-- Property used to filter contents of dynamically collected invoker test.properties. -->
+    <invoker.test.properties.list></invoker.test.properties.list>
   </properties>
 
   <dependencyManagement>
@@ -252,6 +255,23 @@
                   <invokerScriptName>${maven.modules.resolution.selector.script.name}</invokerScriptName>
                   <mavenRepoLocal>${session.request.localRepositoryPath.path}</mavenRepoLocal>
                   <mavenSettings>${session.request.userSettingsFile.path}</mavenSettings>
+                </properties>
+              </configuration>
+            </execution>
+            <execution>
+              <id>write-test-properties-file-for-invoker</id>
+              <phase>none</phase>
+              <goals>
+                <goal>execute</goal>
+              </goals>
+              <configuration>
+                <scripts>
+                  <script>file://${main.basedir}/scripts/write-test-properties-file-for-invoker.groovy</script>
+                </scripts>
+                <properties>
+                  <basedir>${sources.directory}</basedir>
+                  <testPropertiesFileName>test.properties</testPropertiesFileName>
+                  <listedProperties>${invoker.test.properties.list}</listedProperties>
                 </properties>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,9 @@
     <sources.directory.module.project.sources.dependency.get>
       ${main.basedir}/run-tests-with-build-project-sources-dependency-get/target/sources
     </sources.directory.module.project.sources.dependency.get>
+    <sources.directory.module.scm.checkout>
+      ${main.basedir}/run-tests-with-build-scm-checkout/target/sources
+    </sources.directory.module.scm.checkout>
 
     <maven.test.failure.ignore>true</maven.test.failure.ignore>
     <maven.main.skip>false</maven.main.skip>
@@ -110,6 +113,7 @@
     <enforcer.test.type.project.sources>project-sources</enforcer.test.type.project.sources>
     <enforcer.test.type.sources.zip>sources-zip</enforcer.test.type.sources.zip>
     <enforcer.test.type.quickstarts.zip>quickstarts-zip</enforcer.test.type.quickstarts.zip>
+    <enforcer.test.type.scm.checkout>scm-checkout</enforcer.test.type.scm.checkout>
   </properties>
 
   <dependencyManagement>

--- a/run-tests-with-build-kogito-examples-parent/README.md
+++ b/run-tests-with-build-kogito-examples-parent/README.md
@@ -26,6 +26,13 @@ mvn clean verify \
 -Dtest.type=quickstarts-zip \
 -Ddownload.sources.url=http://link.to/quickstarts.zip
 ```
+### Scm-checkout testing
+```
+mvn clean verify \
+-Dtest.type=scm-checkout \
+-Drepository.url=https://github.com/kiegroup/kogito-examples \
+-Dsources.revision=1.11.x
+```
 
 ## Module structure
 Each of sub-modules contains configuration for Maven Invoker related settings.
@@ -35,3 +42,5 @@ Download configuration of particular deliverable is provided by modules
   * Used for downloads from arbitrary url.
 * [run-tests-with-build-project-sources-dependency-get](../run-tests-with-build-project-sources-dependency-get)
   * Used for tar.gz archives with the classifier project-sources from nexus repository.
+* [run-tests-with-build-scm-checkout](../run-tests-with-build-scm-checkout)
+  * Used for git repo checkout using repository URL and revision.

--- a/run-tests-with-build-kogito-examples-parent/README.md
+++ b/run-tests-with-build-kogito-examples-parent/README.md
@@ -34,6 +34,52 @@ mvn clean verify \
 -Dsources.revision=1.11.x
 ```
 
+## Passing system properties
+### Static
+Any system properties that needs to be passed to particular invoked project, and are known
+in advance, they can be configured to invoker-maven-plugin directly in its configuration. An
+example is using the `-Dproductized` property by default in the configuration:
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-invoker-plugin</artifactId>
+  <configuration>
+    <properties>
+      <productized>true</productized>
+    </properties>
+  </configuration>
+</plugin>
+```
+### Dynamic and optional system properties
+If more variability is needed in terms of setting system properties for invoked build - there's an
+optional step that can be added to the `*-test` maven module build section.
+The following step will make sure that system properties are passed to invoked project
+using `invoker-maven-plugin`'s configuration option `<testPropertiesFile>`.
+```xml
+<plugin>
+  <groupId>org.codehaus.gmavenplus</groupId>
+  <artifactId>gmavenplus-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>write-test-properties-file-for-invoker</id>
+      <phase>generate-resources</phase>
+      <goals>
+        <goal>execute</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+```
+By default, all properties passed to run-tests-with-build are passed - this can be changed by
+the configuration property `invoker.test.properties.list`, which is a comma-separated list
+of system properties that are passed (but only if they are actally passed to overall run-tests-with-build maven build).
+This will help you to filter out run-tests-with-build internally used properties (e.g. `-Dtest.type`).
+```xml
+<properties>
+  <invoker.test.properties.list>quarkus.platform.group-id</invoker.test.properties.list>
+</properties>
+```
+
 ## Module structure
 Each of sub-modules contains configuration for Maven Invoker related settings.
 

--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-project-sources-test/pom.xml
@@ -18,6 +18,24 @@
     <quarkus.native.container-build>true</quarkus.native.container-build>
     <quarkus.native.container-runtime>docker</quarkus.native.container-runtime>
     <quarkus.native.builder-image>quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11</quarkus.native.builder-image>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+     The entry in properties file is created only when the value for given property is passed using `-D` to the
+     overall maven build. -->
+    <invoker.test.properties.list>
+      quarkus.platform.group-id,
+      quarkus.platform.artifact-id,
+      quarkus.platform.version,
+      kogito.bom.group-id,
+      kogito.bom.artifact-id,
+      kogito.bom.version,
+      optaplanner.bom.group-id,
+      optaplanner.bom.artifact-id,
+      optaplanner.bom.version,
+      container.image.infinispan,
+      container.image.keycloak,
+      container.image.kafka,
+      container.image.mongodb
+    </invoker.test.properties.list>
   </properties>
 
   <dependencies>
@@ -40,6 +58,19 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
       <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
       <plugin>
         <groupId>org.codehaus.gmavenplus</groupId>
@@ -59,6 +90,8 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
+          <!-- this file is created by write-test-properties-file-for-invoker execution above -->
+          <testPropertiesFile>test.properties</testPropertiesFile>
           <!--
           script deciding if included project is:
             executed (either script missing or returning true)

--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-scm-checkout-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-scm-checkout-test/pom.xml
@@ -12,6 +12,23 @@
 
   <artifactId>kogito-examples-scm-checkout-test</artifactId>
 
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+         The entry in properties file is created only when the value for given property is passed using `-D` to the
+         overall maven build. -->
+    <invoker.test.properties.list>
+      quarkus.platform.group-id,
+      quarkus.platform.artifact-id,
+      quarkus.platform.version,
+      kogito.bom.group-id,
+      kogito.bom.artifact-id,
+      kogito.bom.version,
+      optaplanner.bom.group-id,
+      optaplanner.bom.artifact-id,
+      optaplanner.bom.version
+    </invoker.test.properties.list>
+  </properties>
+
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
@@ -34,6 +51,19 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
@@ -41,6 +71,7 @@
           <properties>
             <productized>true</productized>
           </properties>
+          <testPropertiesFile>test.properties</testPropertiesFile>
           <!-- path relative from the pom.xml location below -->
           <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
           <pomIncludes>

--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-scm-checkout-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-scm-checkout-test/pom.xml
@@ -10,13 +10,13 @@
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
 
-  <artifactId>kogito-examples-quickstarts-zip-test</artifactId>
+  <artifactId>kogito-examples-scm-checkout-test</artifactId>
 
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>run-tests-with-build-sources-zip-download</artifactId>
+      <artifactId>run-tests-with-build-scm-checkout</artifactId>
       <type>pom</type>
       <version>${project.version}</version>
     </dependency>
@@ -42,9 +42,10 @@
             <productized>true</productized>
           </properties>
           <!-- path relative from the pom.xml location below -->
-          <invokerPropertiesFile>../invoker.properties</invokerPropertiesFile>
+          <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
           <pomIncludes>
-            <pomInclude>kogito-examples*/pom.xml</pomInclude>
+            <!-- Building the gitrepo from root pom.xml -->
+            <pomInclude>pom.xml</pomInclude>
           </pomIncludes>
         </configuration>
       </plugin>

--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-sources-zip-test/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
 
-  <artifactId>kogito-runtimes-sources-zip-test</artifactId>
+  <artifactId>kogito-examples-sources-zip-test</artifactId>
 
   <dependencies>
     <!-- define as dependency to assure reactor order -->

--- a/run-tests-with-build-kogito-examples-parent/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/pom.xml
@@ -21,7 +21,7 @@
     <maven.test.failure.ignore>false</maven.test.failure.ignore>
     <!-- just for enforcer activation section of profiles does not interpolate properties -->
     <activation.property.name>test.type</activation.property.name>
-    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.quickstarts.zip})$</enforcer.regex.activation.property>
+    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.quickstarts.zip}|${enforcer.test.type.scm.checkout})$</enforcer.regex.activation.property>
   </properties>
 
   <build>
@@ -103,6 +103,26 @@
       <modules>
         <module>../run-tests-with-build-project-sources-dependency-get</module>
         <module>kogito-examples-project-sources-test</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>kogito-examples-scm-checkout</id>
+      <activation>
+        <property>
+          <name>test.type</name>
+          <value>scm-checkout</value>
+        </property>
+      </activation>
+      <properties>
+        <!-- Invoker expecting sources.directory property to point at sources -->
+        <sources.directory>${sources.directory.module.scm.checkout}</sources.directory>
+        <!-- Needs to be provided upon running the mvn build -->
+        <sources.revision></sources.revision>
+        <sources.revision.type>branch</sources.revision.type>
+      </properties>
+      <modules>
+        <module>../run-tests-with-build-scm-checkout</module>
+        <module>kogito-examples-scm-checkout-test</module>
       </modules>
     </profile>
   </profiles>

--- a/run-tests-with-build-kogito-runtimes-parent/README.md
+++ b/run-tests-with-build-kogito-runtimes-parent/README.md
@@ -21,6 +21,52 @@ mvn clean verify \
 -Ddownload.sources.url=http://link.to/source.zip
 ```
 
+## Passing system properties
+### Static
+Any system properties that needs to be passed to particular invoked project, and are known
+in advance, they can be configured to invoker-maven-plugin directly in its configuration. An
+example is using the `-Dproductized` property by default in the configuration:
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-invoker-plugin</artifactId>
+  <configuration>
+    <properties>
+      <productized>true</productized>
+    </properties>
+  </configuration>
+</plugin>
+```
+### Dynamic and optional system properties
+If more variability is needed in terms of setting system properties for invoked build - there's an
+optional step that can be added to the `*-test` maven module build section.
+The following step will make sure that system properties are passed to invoked project
+using `invoker-maven-plugin`'s configuration option `<testPropertiesFile>`.
+```xml
+<plugin>
+  <groupId>org.codehaus.gmavenplus</groupId>
+  <artifactId>gmavenplus-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>write-test-properties-file-for-invoker</id>
+      <phase>generate-resources</phase>
+      <goals>
+        <goal>execute</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+```
+By default, all properties passed to run-tests-with-build are passed - this can be changed by
+the configuration property `invoker.test.properties.list`, which is a comma-separated list
+of system properties that are passed (but only if they are actally passed to overall run-tests-with-build maven build).
+This will help you to filter out run-tests-with-build internally used properties (e.g. `-Dtest.type`).
+```xml
+<properties>
+  <invoker.test.properties.list>quarkus.platform.group-id</invoker.test.properties.list>
+</properties>
+```
+
 ## Module structure
 Each of sub-modules contains configuration for Maven Invoker related settings.
 

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
@@ -12,6 +12,26 @@
 
   <artifactId>kogito-runtimes-project-sources-test</artifactId>
 
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+    The entry in properties file is created only when the value for given property is passed using `-D` to the
+    overall maven build. -->
+    <invoker.test.properties.list>
+      quarkus.platform.group-id,
+      quarkus.platform.artifact-id,
+      quarkus.platform.version,
+      kogito.bom.group-id,
+      kogito.bom.artifact-id,
+      kogito.bom.version,
+      optaplanner.bom.group-id,
+      optaplanner.bom.artifact-id,
+      optaplanner.bom.version,
+      container.image.infinispan,
+      container.image.keycloak,
+      container.image.kafka,
+      container.image.mongodb
+    </invoker.test.properties.list>
+  </properties>
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
@@ -29,6 +49,19 @@
         <executions>
           <execution>
             <id>copy-invoker-properties</id>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>
@@ -56,6 +89,8 @@
           <execution>
             <id>run-tests</id>
             <configuration>
+              <!-- this file is created by write-test-properties-file-for-invoker execution above -->
+              <testPropertiesFile>test.properties</testPropertiesFile>
               <!-- script deciding if included project is
               executed (either script missing or returning true)
               or skipped (when returns false or throws error) -->

--- a/run-tests-with-build-optaplanner-quickstarts-parent/README.md
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/README.md
@@ -27,6 +27,13 @@ mvn clean verify \
 -Dtest.type=quickstarts-zip \
 -Ddownload.sources.url=http://link.to/quickstarts.zip
 ```
+### Scm-checkout testing
+```
+mvn clean verify \
+-Dtest.type=scm-checkout \
+-Drepository.url=https://github.com/kiegroup/optaplanner-quickstarts \
+-Dsources.revision=8.11.x
+```
 
 ## Module structure
 Each of sub-modules contains configuration for Maven Invoker related settings.
@@ -36,3 +43,5 @@ Download configuration of particular deliverable is provided by modules
   * Used for downloads from arbitrary url.
 * [run-tests-with-build-project-sources-dependency-get](../run-tests-with-build-project-sources-dependency-get)
   * Used for tar.gz archives with the classifier project-sources from nexus repository.
+* [run-tests-with-build-scm-checkout](../run-tests-with-build-scm-checkout)
+  * Used for git repo checkout using repository URL and revision.

--- a/run-tests-with-build-optaplanner-quickstarts-parent/README.md
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/README.md
@@ -34,6 +34,51 @@ mvn clean verify \
 -Drepository.url=https://github.com/kiegroup/optaplanner-quickstarts \
 -Dsources.revision=8.11.x
 ```
+## Passing system properties
+### Static
+Any system properties that needs to be passed to particular invoked project, and are known
+in advance, they can be configured to invoker-maven-plugin directly in its configuration. An
+example is using the `-Dfull` property by default in the configuration:
+```xml
+<plugin>
+  <groupId>org.apache.maven.plugins</groupId>
+  <artifactId>maven-invoker-plugin</artifactId>
+  <configuration>
+    <properties>
+      <full>true</full>
+    </properties>
+  </configuration>
+</plugin>
+```
+### Dynamic and optional system properties
+If more variability is needed in terms of setting system properties for invoked build - there's an
+optional step that can be added to the `*-test` maven module build section.
+The following step will make sure that system properties are passed to invoked project
+using `invoker-maven-plugin`'s configuration option `<testPropertiesFile>`.
+```xml
+<plugin>
+  <groupId>org.codehaus.gmavenplus</groupId>
+  <artifactId>gmavenplus-plugin</artifactId>
+  <executions>
+    <execution>
+      <id>write-test-properties-file-for-invoker</id>
+      <phase>generate-resources</phase>
+      <goals>
+        <goal>execute</goal>
+      </goals>
+    </execution>
+  </executions>
+</plugin>
+```
+By default, all properties passed to run-tests-with-build are passed - this can be changed by
+the configuration property `invoker.test.properties.list`, which is a comma-separated list
+of system properties that are passed (but only if they are actally passed to overall run-tests-with-build maven build).
+This will help you to filter out run-tests-with-build internally used properties (e.g. `-Dtest.type`).
+```xml
+<properties>
+  <invoker.test.properties.list>quarkus.platform.group-id</invoker.test.properties.list>
+</properties>
+```
 
 ## Module structure
 Each of sub-modules contains configuration for Maven Invoker related settings.

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-scm-checkout-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-scm-checkout-test/pom.xml
@@ -3,20 +3,20 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>run-tests-with-build-kogito-examples-parent</artifactId>
+    <artifactId>run-tests-with-build-optaplanner-quickstarts-parent</artifactId>
     <groupId>org.kie</groupId>
     <version>1.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
 
-  <artifactId>kogito-examples-quickstarts-zip-test</artifactId>
+  <artifactId>optaplanner-quickstarts-scm-checkout-test</artifactId>
 
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
       <groupId>org.kie</groupId>
-      <artifactId>run-tests-with-build-sources-zip-download</artifactId>
+      <artifactId>run-tests-with-build-scm-checkout</artifactId>
       <type>pom</type>
       <version>${project.version}</version>
     </dependency>
@@ -38,13 +38,11 @@
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
-          <properties>
-            <productized>true</productized>
-          </properties>
           <!-- path relative from the pom.xml location below -->
-          <invokerPropertiesFile>../invoker.properties</invokerPropertiesFile>
+          <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
           <pomIncludes>
-            <pomInclude>kogito-examples*/pom.xml</pomInclude>
+            <!-- Building the gitrepo from root pom.xml -->
+            <pomInclude>pom.xml</pomInclude>
           </pomIncludes>
         </configuration>
       </plugin>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-scm-checkout-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-scm-checkout-test/pom.xml
@@ -12,6 +12,20 @@
 
   <artifactId>optaplanner-quickstarts-scm-checkout-test</artifactId>
 
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+         The entry in properties file is created only when the value for given property is passed using `-D` to the
+         overall maven build. -->
+    <invoker.test.properties.list>
+      quarkus.platform.group-id,
+      quarkus.platform.artifact-id,
+      quarkus.platform.version,
+      optaplanner.bom.group-id,
+      optaplanner.bom.artifact-id,
+      optaplanner.bom.version
+    </invoker.test.properties.list>
+  </properties>
+
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
@@ -34,10 +48,24 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-invoker-plugin</artifactId>
         <configuration>
           <parallelThreads>1</parallelThreads>
+          <testPropertiesFile>test.properties</testPropertiesFile>
           <!-- path relative from the pom.xml location below -->
           <invokerPropertiesFile>invoker.properties</invokerPropertiesFile>
           <pomIncludes>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-sources-zip-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-sources-zip-test/pom.xml
@@ -10,7 +10,7 @@
   <modelVersion>4.0.0</modelVersion>
   <packaging>pom</packaging>
 
-  <artifactId>optaplanner-sources-zip-test</artifactId>
+  <artifactId>optaplanner-quickstarts-sources-zip-test</artifactId>
 
   <dependencies>
     <!-- define as dependency to assure reactor order -->

--- a/run-tests-with-build-optaplanner-quickstarts-parent/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/pom.xml
@@ -19,7 +19,7 @@
     <maven.test.failure.ignore>false</maven.test.failure.ignore>
     <!-- just for enforcer activation section of profiles does not interpolate properties -->
     <activation.property.name>test.type</activation.property.name>
-    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.quickstarts.zip})$</enforcer.regex.activation.property>
+    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.quickstarts.zip}|${enforcer.test.type.scm.checkout})$</enforcer.regex.activation.property>
   </properties>
 
   <build>
@@ -101,6 +101,26 @@
       <modules>
         <module>../run-tests-with-build-project-sources-dependency-get</module>
         <module>optaplanner-quickstarts-project-sources-test</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>optaplanner-quickstarts-scm-checkout</id>
+      <activation>
+        <property>
+          <name>test.type</name>
+          <value>scm-checkout</value>
+        </property>
+      </activation>
+      <properties>
+        <!-- Invoker expecting sources.directory property to point at sources -->
+        <sources.directory>${sources.directory.module.scm.checkout}</sources.directory>
+        <!-- Needs to be provided upon running the mvn build -->
+        <sources.revision></sources.revision>
+        <sources.revision.type>branch</sources.revision.type>
+      </properties>
+      <modules>
+        <module>../run-tests-with-build-scm-checkout</module>
+        <module>optaplanner-quickstarts-scm-checkout-test</module>
       </modules>
     </profile>
   </profiles>

--- a/run-tests-with-build-scm-checkout/pom.xml
+++ b/run-tests-with-build-scm-checkout/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
+
+  <artifactId>run-tests-with-build-scm-checkout</artifactId>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules combine.children="append">
+                <requireProperty>
+                  <property>repository.url</property>
+                  <message>Property repository.url is not set!</message>
+                  <regex>.+</regex>
+                  <regexMessage>Property repository.url is not set.</regexMessage>
+                </requireProperty>
+                <requireProperty>
+                  <property>sources.revision</property>
+                  <message>Property sources.revision is not set!</message>
+                  <regex>.+</regex>
+                  <regexMessage>Property sources.revision is not set.</regexMessage>
+                </requireProperty>
+                <requireProperty>
+                  <property>sources.revision.type</property>
+                  <message>Property sources.revision.type is not set!</message>
+                  <regex>branch|tag|revision</regex>
+                  <regexMessage>Property sources.revision.type is not set.</regexMessage>
+                </requireProperty>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>checkout-repository</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>checkout</goal>
+            </goals>
+            <configuration combine.self="override">
+              <connectionUrl>scm:git:${repository.url}</connectionUrl>
+              <checkoutDirectory>${sources.directory.module.scm.checkout}</checkoutDirectory>
+              <scmVersion>${sources.revision}</scmVersion>
+              <scmVersionType>${sources.revision.type}</scmVersionType>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/scripts/write-test-properties-file-for-invoker.groovy
+++ b/scripts/write-test-properties-file-for-invoker.groovy
@@ -1,0 +1,41 @@
+import java.util.stream.Collectors
+
+/**
+ * Contents of test.properties file to be written. Contains key=value entries.
+ * If inputListAsString argument is not an empty string, only subset of system properties is written,
+ * based on the provided comma separated list of properties.
+ * @param inputListAsString subset of system properties to be written to file, empty string to include all
+ * @return String with contents of the file
+ */
+private String getTestPropertiesFileContents(String inputListAsString) {
+    Properties systemProperties = session.userProperties
+    Set<String> resultingProperties = systemProperties.keySet()
+
+    def listOfPropertiesToWrite = inputListAsString.split(',').toList()
+    if (listOfPropertiesToWrite.size() > 0) {
+        resultingProperties.removeIf({ it -> !listOfPropertiesToWrite.contains(it) })
+    }
+    return resultingProperties.stream()
+            .map(it -> "$it=${session.userProperties[it]}")
+            .collect(Collectors.joining("\n"))
+}
+/**
+ * Method that writes test properties file next to each pom.xml file. The name of the newly
+ * created file is the first parameter.
+ * The search for pom.xml files starts at location denoted by basedir configuration option.
+ * @param fileName of the newly created file.
+ * @param contentsToWrite Contents of the file to be written
+ */
+private void writeTestProperties(String fileName, String contentsToWrite) {
+    log.info("Contents of properties file being written:\n$contentsToWrite")
+    new File(basedir).eachFileRecurse { it ->
+        if (it.name.equalsIgnoreCase("pom.xml")) {
+            def testPropsFile = new File(it.getParent(), fileName)
+            log.info("Writing properties as $testPropsFile")
+            testPropsFile.write(contentsToWrite)
+        }
+    }
+}
+
+String contentsToWrite = getTestPropertiesFileContents(listedProperties)
+writeTestProperties(testPropertiesFileName, contentsToWrite)


### PR DESCRIPTION
There are two commits:

1. Adding support for scm-checkout test.type, which allows cloning tests directly from branch.
a. This is applicable in cases where projects themselves allow for version overrides, like for BOMs in kogito-examples and optaplanner-quickstarts.
2. Adding support for passing system properties through invoker.
a. Groovy script to get properties not defined in pom.xml into test.properties (passed to overall run-tests-with-build using `-Dkogito.bom.group-id` for example).
b. Test properties file is placed next to each pom.xml file inside the sources directory (recursively).
c. The behavior is pluggable, by default turned off, requires plugin entry inside module's build section.
