### PR TITLE
Change url to main branch of the test resource

### DIFF
--- a/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-vehicle-routing-test-script-openshift.sh
+++ b/run-tests-with-build-optawebs-parent/optawebs-project-sources-test/optaweb-vehicle-routing-test-script-openshift.sh
@@ -32,7 +32,7 @@ readonly project_basedir=$1
 }
 
 #open street map git url
-readonly test_osm_data_url="https://github.com/kiegroup/optaweb-vehicle-routing/raw/master/optaweb-vehicle-routing-standalone/data/openstreetmap/planet_12.032%2C53.0171_12.1024%2C53.0491.osm.pbf"
+readonly test_osm_data_url="https://github.com/kiegroup/optaweb-vehicle-routing/raw/main/optaweb-vehicle-routing-standalone/data/openstreetmap/planet_12.032%2C53.0171_12.1024%2C53.0491.osm.pbf"
 
 # login to OpenShift
 readonly openshift_api_url=$3


### PR DESCRIPTION
The old link has been supported for a long time, but recently it dropped(finally)