### PR TITLE
enable quarkus-plugin.version property override

### DIFF
--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-project-sources-test/pom.xml
@@ -25,6 +25,7 @@
       quarkus.platform.group-id,
       quarkus.platform.artifact-id,
       quarkus.platform.version,
+      quarkus-plugin.version,
       kogito.bom.group-id,
       kogito.bom.artifact-id,
       kogito.bom.version,

--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-scm-checkout-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-scm-checkout-test/pom.xml
@@ -20,6 +20,7 @@
       quarkus.platform.group-id,
       quarkus.platform.artifact-id,
       quarkus.platform.version,
+      quarkus-plugin.version,
       kogito.bom.group-id,
       kogito.bom.artifact-id,
       kogito.bom.version,

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
@@ -20,6 +20,7 @@
       quarkus.platform.group-id,
       quarkus.platform.artifact-id,
       quarkus.platform.version,
+      quarkus-plugin.version,
       kogito.bom.group-id,
       kogito.bom.artifact-id,
       kogito.bom.version,

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-scm-checkout-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-scm-checkout-test/pom.xml
@@ -20,6 +20,7 @@
       quarkus.platform.group-id,
       quarkus.platform.artifact-id,
       quarkus.platform.version,
+      quarkus-plugin.version,
       optaplanner.bom.group-id,
       optaplanner.bom.artifact-id,
       optaplanner.bom.version


### PR DESCRIPTION
Adding property quarkus-plugin.version as a possible override for kogito-runtimes, kogito-examples and optaplanner-quickstarts.