### PR TITLE
[serverless-logic-1.24.x] kogito-runtimes|examples-sources-zip: Fix POM files location

### DIFF
--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-sources-zip-test/pom.xml
@@ -44,7 +44,7 @@
           <!-- path relative from the pom.xml location below -->
           <invokerPropertiesFile>../../invoker.properties</invokerPropertiesFile>
           <pomIncludes>
-            <pomInclude>kogito-*/*kogito-examples*/pom.xml</pomInclude>
+            <pomInclude>*/*kogito-examples*/pom.xml</pomInclude>
           </pomIncludes>
         </configuration>
       </plugin>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
@@ -53,7 +53,7 @@
               <!-- path relative to the poms included below -->
               <invokerPropertiesFile>../../invoker.properties</invokerPropertiesFile>
               <pomIncludes>
-                <pomInclude>kogito-*/*kogito-runtimes*/pom.xml</pomInclude>
+                <pomInclude>*/*kogito-runtimes*/pom.xml</pomInclude>
               </pomIncludes>
             </configuration>
           </execution>

--- a/run-tests-with-build-optaplanner-parent/optaplanner-sources-zip-test/pom.xml
+++ b/run-tests-with-build-optaplanner-parent/optaplanner-sources-zip-test/pom.xml
@@ -41,10 +41,10 @@
           <!-- path relative from the pom.xml location below -->
           <invokerPropertiesFile>../../invoker.properties</invokerPropertiesFile>
           <pomIncludes>
-            <pomInclude>kogito-*/*optaplanner*/pom.xml</pomInclude>
+            <pomInclude>*/*optaplanner*/pom.xml</pomInclude>
           </pomIncludes>
           <pomExcludes>
-            <pomExclude>kogito-*/*optaplanner-quickstarts*/pom.xml</pomExclude>
+            <pomExclude>*/*optaplanner-quickstarts*/pom.xml</pomExclude>
           </pomExcludes>
         </configuration>
       </plugin>

--- a/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-sources-zip-test/pom.xml
+++ b/run-tests-with-build-optaplanner-quickstarts-parent/optaplanner-quickstarts-sources-zip-test/pom.xml
@@ -41,7 +41,7 @@
           <!-- path relative from the pom.xml location below -->
           <invokerPropertiesFile>../../invoker.properties</invokerPropertiesFile>
           <pomIncludes>
-            <pomInclude>kogito-*/*optaplanner-quickstarts*/pom.xml</pomInclude>
+            <pomInclude>*/*optaplanner-quickstarts*/pom.xml</pomInclude>
           </pomIncludes>
         </configuration>
       </plugin>

--- a/run-tests-with-build-optawebs-parent/optawebs-sources-zip-test/pom.xml
+++ b/run-tests-with-build-optawebs-parent/optawebs-sources-zip-test/pom.xml
@@ -41,7 +41,7 @@
           <invokerPropertiesFile>../../invoker.properties</invokerPropertiesFile>
           <pomIncludes>
             <!-- relying here that which particular of the optaweb apps is tested is decided in run-tests-with-build-sources-zip-download -->
-            <pomInclude>kogito-*/*optaweb*/pom.xml</pomInclude>
+            <pomInclude>*/*optaweb*/pom.xml</pomInclude>
           </pomIncludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
The structure of the sources zip is:
* openshift-serverless-logic-\<version\>-src
  * org.kie.kogito-kogito-runtimes-\<version\>
  * and so on

Changes already tested on pipelines.
