### PR TITLE
[serverless-logic-1.24.x] BAQE 2203 - add unpack-build-maven-plugin fix unpack.build.version property

### DIFF
--- a/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
+++ b/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
@@ -52,7 +52,7 @@
         <configuration>
           <goals>
             <goal>clean</goal>
-            <goal>org.kie:unpack-build-maven-plugin:1.0-SNAPSHOT:unpack-build</goal>
+            <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
             <goal>verify</goal>
           </goals>
           <!-- script deciding if included project is


### PR DESCRIPTION
Replace hard-coded 1.0-SNAPSHOT version by the property unpack.build.version.