### PR TITLE
[1.35.x-for real now] KOGITO-8800 - Allow to use a separate image for Data Index Dev Servic…

### DIFF
--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
@@ -21,7 +21,7 @@
       container.image.keycloak,
       container.image.kafka,
       container.image.mongodb,
-      data-index-ephemeral.image
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <maven.main.skip>true</maven.main.skip>
   </properties>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
@@ -21,7 +21,7 @@
       container.image.keycloak,
       container.image.kafka,
       container.image.mongodb,
-      data-index-ephemeral.image
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <!-- We DON'T want to skip main compilation, sources-zip is supposed to validate full build -->
     <maven.main.skip>false</maven.main.skip>


### PR DESCRIPTION
…e Test

And this time to the correct branch.