### PR TITLE
Add local-repo test.type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
     <enforcer.test.type.sources.zip>sources-zip</enforcer.test.type.sources.zip>
     <enforcer.test.type.quickstarts.zip>quickstarts-zip</enforcer.test.type.quickstarts.zip>
     <enforcer.test.type.scm.checkout>scm-checkout</enforcer.test.type.scm.checkout>
+    <enforcer.test.type.local.repo>local-repo</enforcer.test.type.local.repo>
 
     <!-- Property used to filter contents of dynamically collected invoker test.properties. -->
     <invoker.test.properties.list></invoker.test.properties.list>

--- a/run-tests-with-build-drools-parent/README.md
+++ b/run-tests-with-build-drools-parent/README.md
@@ -1,7 +1,7 @@
-# Kogito Runtimes Parent
+# Drools Parent
 
 ## Description
-This module serves as an invocation point for tests of kogito-runtimes repository.
+This module serves as an invocation point for tests of drools repository.
 
 ## Usage
 Project pom defines profiles that can invoke tests for a particular delivery option.
@@ -11,14 +11,8 @@ Download of artifacts is provided by means described in [Module structure](#modu
 ```
 mvn clean verify \
 -Dtest.type=project-sources \
--Dproject.sources.artifact=kogito-runtimes \
+-Dproject.sources.artifact=drools \
 -Ddownload.sources.version=<VERSION>
-```
-### Sources-zip testing
-```
-mvn clean verify \
--Dtest.type=sources-zip \
--Ddownload.sources.url=http://link.to/source.zip
 ```
 ### Local-repo testing
 ```
@@ -65,7 +59,7 @@ using `invoker-maven-plugin`'s configuration option `<testPropertiesFile>`.
 ```
 By default, all properties passed to run-tests-with-build are passed - this can be changed by
 the configuration property `invoker.test.properties.list`, which is a comma-separated list
-of system properties that are passed (but only if they are actally passed to overall run-tests-with-build maven build).
+of system properties that are passed (but only if they are actually passed to overall run-tests-with-build maven build).
 This will help you to filter out run-tests-with-build internally used properties (e.g. `-Dtest.type`).
 ```xml
 <properties>

--- a/run-tests-with-build-drools-parent/drools-local-repo-test/pom.xml
+++ b/run-tests-with-build-drools-parent/drools-local-repo-test/pom.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build-drools-parent</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
+
+  <artifactId>drools-local-repo-test</artifactId>
+
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+    The entry in properties file is created only when the value for given property is passed using `-D` to the
+    overall maven build. -->
+    <invoker.test.properties.list>
+    </invoker.test.properties.list>
+    <maven.main.skip>true</maven.main.skip>
+  </properties>
+  <dependencies>
+    <!-- no dependency for getting the sources is needed, invoking on provided sources path -->
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules combine.children="append">
+                <requireProperty>
+                  <property>sources.directory.local.repo</property>
+                  <message>Property sources.directory.local.repo is not set!</message>
+                  <regex>.*\W+.*</regex>
+                  <regexMessage>Property sources.directory.local.repo does not contain value.</regexMessage>
+                </requireProperty>
+                <requireFilesExist>
+                  <message>Property sources.directory.local.repo does not reference existing location: '${sources.directory.local.repo}'</message>
+                  <files>
+                    <file>${sources.directory.local.repo}</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+              <failFast>true</failFast>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-invoker-properties</id>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+          <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
+          <execution>
+            <id>resolve-includes</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <parallelThreads>1</parallelThreads>
+          <goals>
+            <goal>clean</goal>
+            <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
+            <goal>verify</goal>
+          </goals>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-tests</id>
+            <configuration>
+              <!-- this file is created by write-test-properties-file-for-invoker execution above -->
+              <testPropertiesFile>test.properties</testPropertiesFile>
+              <!-- script deciding if included project is
+              executed (either script missing or returning true)
+              or skipped (when returns false or throws error) -->
+              <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
+              <pomIncludes>
+                <!-- includes everything, filtering is done in resolve-includes.groovy script
+                which adds invoker-run.groovy script containing 'return false' near each pom.xml
+                that should be excluded.-->
+                <pomInclude>**/pom.xml</pomInclude>
+              </pomIncludes>
+              <pomExcludes>
+                <!-- Excludes work still as expected. -->
+              </pomExcludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
+++ b/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
@@ -12,6 +12,14 @@
 
   <artifactId>drools-project-sources-test</artifactId>
 
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+    The entry in properties file is created only when the value for given property is passed using `-D` to the
+    overall maven build. -->
+    <invoker.test.properties.list>
+    </invoker.test.properties.list>
+    <maven.main.skip>true</maven.main.skip>
+  </properties>
   <dependencies>
     <!-- define as dependency to assure reactor order -->
     <dependency>
@@ -37,6 +45,13 @@
         <groupId>org.codehaus.gmavenplus</groupId>
         <artifactId>gmavenplus-plugin</artifactId>
         <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
           <execution>
             <id>resolve-includes</id>
             <phase>generate-resources</phase>

--- a/run-tests-with-build-drools-parent/pom.xml
+++ b/run-tests-with-build-drools-parent/pom.xml
@@ -18,7 +18,7 @@
     <maven.test.failure.ignore>false</maven.test.failure.ignore>
     <!-- just for enforcer activation section of profiles does not interpolate properties -->
     <activation.property.name>test.type</activation.property.name>
-    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources})$</enforcer.regex.activation.property>
+    <enforcer.regex.activation.property>^(${enforcer.test.type.project.sources}|${enforcer.test.type.local.repo})$</enforcer.regex.activation.property>
   </properties>
 
   <build>
@@ -67,6 +67,21 @@
       <modules>
         <module>../run-tests-with-build-project-sources-dependency-get</module>
         <module>drools-project-sources-test</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>drools-local-repo</id>
+      <activation>
+        <property>
+          <name>test.type</name>
+          <value>local-repo</value>
+        </property>
+      </activation>
+      <properties>
+        <sources.directory>${sources.directory.local.repo}</sources.directory>
+      </properties>
+      <modules>
+        <module>drools-local-repo-test</module>
       </modules>
     </profile>
   </profiles>

--- a/run-tests-with-build-kogito-apps-parent/README.md
+++ b/run-tests-with-build-kogito-apps-parent/README.md
@@ -20,6 +20,12 @@ mvn clean verify \
 -Dtest.type=sources-zip \
 -Ddownload.sources.url=http://link.to/source.zip
 ```
+### Local-repo testing
+```
+mvn clean verify \
+-Dtest.type=local-repo \
+-Dsources.directory.local.repo=/path/to/cloned/repo
+```
 
 ## Passing system properties
 ### Static

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build-kogito-apps-parent</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
+
+  <artifactId>kogito-apps-local-repo-test</artifactId>
+
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+    The entry in properties file is created only when the value for given property is passed using `-D` to the
+    overall maven build. -->
+    <invoker.test.properties.list>
+      container.image.infinispan,
+      container.image.keycloak,
+      container.image.kafka,
+      container.image.mongodb,
+      quarkus.container-image.build
+    </invoker.test.properties.list>
+    <maven.main.skip>true</maven.main.skip>
+  </properties>
+  <dependencies>
+    <!-- no dependency for getting the sources is needed, invoking on provided sources path -->
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules combine.children="append">
+                <requireProperty>
+                  <property>sources.directory.local.repo</property>
+                  <message>Property sources.directory.local.repo is not set!</message>
+                  <regex>.*\W+.*</regex>
+                  <regexMessage>Property sources.directory.local.repo does not contain value.</regexMessage>
+                </requireProperty>
+                <requireFilesExist>
+                  <message>Property sources.directory.local.repo does not reference existing location: '${sources.directory.local.repo}'</message>
+                  <files>
+                    <file>${sources.directory.local.repo}</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+              <failFast>true</failFast>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-invoker-properties</id>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+          <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
+          <execution>
+            <id>resolve-includes</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <parallelThreads>1</parallelThreads>
+          <goals>
+            <goal>clean</goal>
+            <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
+            <goal>verify</goal>
+          </goals>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-tests</id>
+            <configuration>
+              <!-- this file is created by write-test-properties-file-for-invoker execution above -->
+              <testPropertiesFile>test.properties</testPropertiesFile>
+              <!-- script deciding if included project is
+              executed (either script missing or returning true)
+              or skipped (when returns false or throws error) -->
+              <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
+              <pomIncludes>
+                <!-- includes everything, filtering is done in resolve-includes.groovy script
+                which adds invoker-run.groovy script containing 'return false' near each pom.xml
+                that should be excluded.-->
+                <pomInclude>**/pom.xml</pomInclude>
+              </pomIncludes>
+              <pomExcludes>
+                <!-- Excludes work still as expected. -->
+              </pomExcludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/run-tests-with-build-kogito-apps-parent/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/pom.xml
@@ -17,7 +17,7 @@
     <maven.test.failure.ignore>false</maven.test.failure.ignore>
     <!-- just for enforcer activation section of profiles does not interpolate properties -->
     <activation.property.name>test.type</activation.property.name>
-    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources})$</enforcer.regex.activation.property>
+    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.local.repo})$</enforcer.regex.activation.property>
   </properties>
 
   <build>
@@ -82,6 +82,21 @@
       <modules>
         <module>../run-tests-with-build-project-sources-dependency-get</module>
         <module>kogito-apps-project-sources-test</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>kogito-apps-local-repo</id>
+      <activation>
+        <property>
+          <name>test.type</name>
+          <value>local-repo</value>
+        </property>
+      </activation>
+      <properties>
+        <sources.directory>${sources.directory.local.repo}</sources.directory>
+      </properties>
+      <modules>
+        <module>kogito-apps-local-repo-test</module>
       </modules>
     </profile>
   </profiles>

--- a/run-tests-with-build-kogito-examples-parent/README.md
+++ b/run-tests-with-build-kogito-examples-parent/README.md
@@ -33,6 +33,12 @@ mvn clean verify \
 -Drepository.url=https://github.com/kiegroup/kogito-examples \
 -Dsources.revision=1.11.x
 ```
+### Local-repo testing
+```
+mvn clean verify \
+-Dtest.type=local-repo \
+-Dsources.directory.local.repo=/path/to/cloned/repo
+```
 
 ## Passing system properties
 ### Static

--- a/run-tests-with-build-kogito-examples-parent/kogito-examples-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/kogito-examples-local-repo-test/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build-kogito-examples-parent</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
+
+  <artifactId>kogito-examples-local-repo-test</artifactId>
+
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+    The entry in properties file is created only when the value for given property is passed using `-D` to the
+    overall maven build. -->
+    <invoker.test.properties.list>
+      quarkus.platform.group-id,
+      quarkus.platform.artifact-id,
+      quarkus.platform.version,
+      quarkus-plugin.version,
+      kogito.bom.group-id,
+      kogito.bom.artifact-id,
+      kogito.bom.version,
+      container.image.infinispan,
+      container.image.keycloak,
+      container.image.kafka,
+      container.image.mongodb
+    </invoker.test.properties.list>
+  </properties>
+  <dependencies>
+    <!-- no dependency for getting the sources is needed, invoking on provided sources path -->
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules combine.children="append">
+                <requireProperty>
+                  <property>sources.directory.local.repo</property>
+                  <message>Property sources.directory.local.repo is not set!</message>
+                  <regex>.*\W+.*</regex>
+                  <regexMessage>Property sources.directory.local.repo does not contain value.</regexMessage>
+                </requireProperty>
+                <requireFilesExist>
+                  <message>Property sources.directory.local.repo does not reference existing location: '${sources.directory.local.repo}'</message>
+                  <files>
+                    <file>${sources.directory.local.repo}</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+              <failFast>true</failFast>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-invoker-properties</id>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+          <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
+          <execution>
+            <id>resolve-includes</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <parallelThreads>1</parallelThreads>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-tests</id>
+            <configuration>
+              <!-- this file is created by write-test-properties-file-for-invoker execution above -->
+              <testPropertiesFile>test.properties</testPropertiesFile>
+              <!-- script deciding if included project is
+              executed (either script missing or returning true)
+              or skipped (when returns false or throws error) -->
+              <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
+              <pomIncludes>
+                <!-- includes everything, filtering is done in resolve-includes.groovy script
+                which adds invoker-run.groovy script containing 'return false' near each pom.xml
+                that should be excluded.-->
+                <pomInclude>**/pom.xml</pomInclude>
+              </pomIncludes>
+              <pomExcludes>
+                <!-- Excludes work still as expected. -->
+              </pomExcludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/run-tests-with-build-kogito-examples-parent/pom.xml
+++ b/run-tests-with-build-kogito-examples-parent/pom.xml
@@ -21,7 +21,7 @@
     <maven.test.failure.ignore>false</maven.test.failure.ignore>
     <!-- just for enforcer activation section of profiles does not interpolate properties -->
     <activation.property.name>test.type</activation.property.name>
-    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.quickstarts.zip}|${enforcer.test.type.scm.checkout})$</enforcer.regex.activation.property>
+    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.quickstarts.zip}|${enforcer.test.type.scm.checkout}|${enforcer.test.type.local.repo})$</enforcer.regex.activation.property>
   </properties>
 
   <build>
@@ -123,6 +123,21 @@
       <modules>
         <module>../run-tests-with-build-scm-checkout</module>
         <module>kogito-examples-scm-checkout-test</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>kogito-examples-local-repo</id>
+      <activation>
+        <property>
+          <name>test.type</name>
+          <value>local-repo</value>
+        </property>
+      </activation>
+      <properties>
+        <sources.directory>${sources.directory.local.repo}</sources.directory>
+      </properties>
+      <modules>
+        <module>kogito-examples-local-repo-test</module>
       </modules>
     </profile>
   </profiles>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>run-tests-with-build-kogito-runtimes-parent</artifactId>
+    <groupId>org.kie</groupId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+  <packaging>pom</packaging>
+
+  <artifactId>kogito-runtimes-local-repo-test</artifactId>
+
+  <properties>
+    <!-- Following are being passed to invoked projects as system properties using testPropertiesFile in invoker.
+    The entry in properties file is created only when the value for given property is passed using `-D` to the
+    overall maven build. -->
+    <invoker.test.properties.list>
+      container.image.infinispan,
+      container.image.keycloak,
+      container.image.kafka,
+      container.image.mongodb,
+      data-index-ephemeral.image.test
+    </invoker.test.properties.list>
+    <maven.main.skip>true</maven.main.skip>
+  </properties>
+  <dependencies>
+    <!-- no dependency for getting the sources is needed, invoking on provided sources path -->
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-property</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules combine.children="append">
+                <requireProperty>
+                  <property>sources.directory.local.repo</property>
+                  <message>Property sources.directory.local.repo is not set!</message>
+                  <regex>.*\W+.*</regex>
+                  <regexMessage>Property sources.directory.local.repo does not contain value.</regexMessage>
+                </requireProperty>
+                <requireFilesExist>
+                  <message>Property sources.directory.local.repo does not reference existing location: '${sources.directory.local.repo}'</message>
+                  <files>
+                    <file>${sources.directory.local.repo}</file>
+                  </files>
+                </requireFilesExist>
+              </rules>
+              <fail>true</fail>
+              <failFast>true</failFast>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>copy-invoker-properties</id>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>write-test-properties-file-for-invoker</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+          <!-- Invoking groovy script that dynamically decides if project should be included in build or not -->
+          <execution>
+            <id>resolve-includes</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>execute</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-invoker-plugin</artifactId>
+        <configuration>
+          <parallelThreads>1</parallelThreads>
+          <goals>
+            <goal>clean</goal>
+            <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
+            <goal>verify</goal>
+          </goals>
+        </configuration>
+        <executions>
+          <execution>
+            <id>run-tests</id>
+            <configuration>
+              <!-- this file is created by write-test-properties-file-for-invoker execution above -->
+              <testPropertiesFile>test.properties</testPropertiesFile>
+              <!-- script deciding if included project is
+              executed (either script missing or returning true)
+              or skipped (when returns false or throws error) -->
+              <selectorScript>${maven.modules.resolution.selector.script.name}</selectorScript>
+              <pomIncludes>
+                <!-- includes everything, filtering is done in resolve-includes.groovy script
+                which adds invoker-run.groovy script containing 'return false' near each pom.xml
+                that should be excluded.-->
+                <pomInclude>**/pom.xml</pomInclude>
+              </pomIncludes>
+              <pomExcludes>
+                <!-- Excludes work still as expected. -->
+              </pomExcludes>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/run-tests-with-build-kogito-runtimes-parent/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/pom.xml
@@ -17,7 +17,7 @@
     <maven.test.failure.ignore>false</maven.test.failure.ignore>
     <!-- just for enforcer activation section of profiles does not interpolate properties -->
     <activation.property.name>test.type</activation.property.name>
-    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources})$</enforcer.regex.activation.property>
+    <enforcer.regex.activation.property>^(${enforcer.test.type.sources.zip}|${enforcer.test.type.project.sources}|${enforcer.test.type.local.repo})$</enforcer.regex.activation.property>
   </properties>
 
   <build>
@@ -82,6 +82,21 @@
       <modules>
         <module>../run-tests-with-build-project-sources-dependency-get</module>
         <module>kogito-runtimes-project-sources-test</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>kogito-runtimes-local-repo</id>
+      <activation>
+        <property>
+          <name>test.type</name>
+          <value>local-repo</value>
+        </property>
+      </activation>
+      <properties>
+        <sources.directory>${sources.directory.local.repo}</sources.directory>
+      </properties>
+      <modules>
+        <module>kogito-runtimes-local-repo-test</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
Adding option to invoke tests on local directory.

* Adding `test.type=local-repo`
* Adding property `sources.directory.local.repo`
  * Checked for non-empty value
  * Checked for existing path
* Removing incorrect sources-zip test.type for drools (was not implemented, but there were some traces)
* Adding readme for drools-parent.