### PR TITLE
[kie-issues#274] parameterize final invoker goal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,10 @@
 
     <!-- Property used to filter contents of dynamically collected invoker test.properties. -->
     <invoker.test.properties.list></invoker.test.properties.list>
+    <invoker.goal.test>test</invoker.goal.test>
+    <invoker.goal.verify>verify</invoker.goal.verify>
+    <invoker.goal.install>install</invoker.goal.install>
+    <invoker.goal>${invoker.goal.verify}</invoker.goal>
   </properties>
 
   <dependencyManagement>
@@ -206,7 +210,7 @@
             </properties>
             <goals>
               <goal>clean</goal>
-              <goal>verify</goal>
+              <goal>${invoker.goal}</goal>
             </goals>
           </configuration>
           <executions>

--- a/run-tests-with-build-drools-parent/drools-local-repo-test/pom.xml
+++ b/run-tests-with-build-drools-parent/drools-local-repo-test/pom.xml
@@ -93,7 +93,7 @@
           <goals>
             <goal>clean</goal>
             <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
-            <goal>verify</goal>
+            <goal>${invoker.goal}</goal>
           </goals>
         </configuration>
         <executions>

--- a/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
+++ b/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
@@ -68,7 +68,7 @@
           <goals>
             <goal>clean</goal>
             <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
-            <goal>verify</goal>
+            <goal>${invoker.goal}</goal>
           </goals>
           <!-- script deciding if included project is
           executed (either script missing or returning true)

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
@@ -98,7 +98,7 @@
           <goals>
             <goal>clean</goal>
             <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
-            <goal>verify</goal>
+            <goal>${invoker.goal}</goal>
           </goals>
         </configuration>
         <executions>

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
@@ -80,7 +80,7 @@
           <goals>
             <goal>clean</goal>
             <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
-            <goal>verify</goal>
+            <goal>${invoker.goal}</goal>
           </goals>
         </configuration>
         <executions>

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
@@ -25,6 +25,7 @@
     </invoker.test.properties.list>
     <!-- We DON'T want to skip main compilation, sources-zip is supposed to validate full build -->
     <maven.main.skip>false</maven.main.skip>
+    <invoker.goal>${invoker.goal.install}</invoker.goal>
   </properties>
 
   <dependencies>
@@ -73,7 +74,7 @@
             <configuration>
               <goals>
                 <goal>clean</goal>
-                <goal>install</goal> <!-- ok to install, will build full project from parent - all is taken from reactor anyway -->
+                <goal>${invoker.goal}</goal> <!-- ok to install, will build full project from parent - all is taken from reactor anyway -->
                 <goal>-pl !ui-packages</goal> <!-- JS module -->
               </goals>
               <!-- this file is created by write-test-properties-file-for-invoker execution above -->

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
@@ -98,7 +98,7 @@
           <goals>
             <goal>clean</goal>
             <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
-            <goal>verify</goal>
+            <goal>${invoker.goal}</goal>
           </goals>
         </configuration>
         <executions>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
@@ -80,7 +80,7 @@
           <goals>
             <goal>clean</goal>
             <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
-            <goal>verify</goal>
+            <goal>${invoker.goal}</goal>
           </goals>
         </configuration>
         <executions>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
@@ -25,6 +25,7 @@
     </invoker.test.properties.list>
     <!-- We DON'T want to skip main compilation, sources-zip is supposed to validate full build -->
     <maven.main.skip>false</maven.main.skip>
+    <invoker.goal>${invoker.goal.install}</invoker.goal>
   </properties>
 
   <dependencies>
@@ -74,7 +75,7 @@
             <configuration>
               <goals>
                 <goal>clean</goal>
-                <goal>install</goal> <!-- ok to install, will build full project from parent - all is taken from reactor anyway -->
+                <goal>${invoker.goal}</goal> <!-- ok to install, will build full project from parent - all is taken from reactor anyway -->
               </goals>
               <!-- this file is created by write-test-properties-file-for-invoker execution above -->
               <testPropertiesFile>test.properties</testPropertiesFile>

--- a/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
+++ b/run-tests-with-build-optaplanner-parent/optaplanner-project-sources-test/pom.xml
@@ -62,7 +62,7 @@
           <goals>
             <goal>clean</goal>
             <goal>org.kie:unpack-build-maven-plugin:${unpack.build.version}:unpack-build</goal>
-            <goal>verify</goal>
+            <goal>${invoker.goal}</goal>
           </goals>
           <properties>
             <productized>true</productized>


### PR DESCRIPTION
Parameterizing the final (last) invoker plugin goal.

Use case - sometimes it's enough to run `test` on a project, other times `integration-test` or `verify`.

In root pom.xml
* Introducing `invoker.goal` property with default value `verify` and using where goal `verify` used to be.
* Introducing explicit properties for used goals, e.g. `invoker.goal.verify`, `invoker.goal.test`.
* Setting `${invoker.goal}` value to the pluginManagement default configuration.

In children's pom.xml:
* Use property `${invoker.goal}` for the last goal in invoker plugin execution.

In some of child pom.xml:
* Override `invoker.goal` with a different goal, e.g. `${invoker.goal.install}`
  * This keeps things in sync when overriding using `-Dinvoker.goal`, the other option, directly using `${invoker.goal.install}` in the plugin config, would lead to inability to override (if/when needed).
