### PR TITLE
resolve-includes.groovy: Fix Path.of() signature

### DIFF
--- a/scripts/resolve-includes.groovy
+++ b/scripts/resolve-includes.groovy
@@ -55,7 +55,7 @@ private File getRootPomLocation(String basedir) {
                     "Directory ${basedir} does not contain pom.xml, and does not have single child directory " +
                             "(has ${childDirs.size()}). Check the basedir value passed to resolve-includes.groovy script.")
         }
-        if (!Path.of(childDirs[0], "pom.xml").toFile().exists()) {
+        if (!Path.of(childDirs[0].toString(), "pom.xml").toFile().exists()) {
             throw new RuntimeException(
                     "Directory ${basedir} does not contain pom.xml, nor does its only child directory (${childDirs[0].toPath()}. " +
                             "Check the basedir value passed to resolve-includes.groovy script."


### PR DESCRIPTION
InvocationTargetException: No signature of method: static java.nio.file.Path.of() is applicable for argument types: (File, String) :wink: 