### PR TITLE
KOGITO-9523 - Move Data Index DevService test to kogito-apps

### DIFF
--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
@@ -21,7 +21,8 @@
       container.image.keycloak,
       container.image.kafka,
       container.image.mongodb,
-      quarkus.container-image.build
+      quarkus.container-image.build,
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <maven.main.skip>true</maven.main.skip>
   </properties>

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
@@ -21,7 +21,8 @@
       container.image.keycloak,
       container.image.kafka,
       container.image.mongodb,
-      quarkus.container-image.build
+      quarkus.container-image.build,
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <maven.main.skip>true</maven.main.skip>
   </properties>

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
@@ -21,7 +21,8 @@
       container.image.keycloak,
       container.image.kafka,
       container.image.mongodb,
-      quarkus.container-image.build
+      quarkus.container-image.build,
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <!-- We DON'T want to skip main compilation, sources-zip is supposed to validate full build -->
     <maven.main.skip>false</maven.main.skip>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
@@ -20,8 +20,7 @@
       container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,
-      container.image.mongodb,
-      data-index-ephemeral.image.test
+      container.image.mongodb
     </invoker.test.properties.list>
     <maven.main.skip>true</maven.main.skip>
   </properties>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
@@ -20,8 +20,7 @@
       container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,
-      container.image.mongodb,
-      data-index-ephemeral.image.test
+      container.image.mongodb
     </invoker.test.properties.list>
     <maven.main.skip>true</maven.main.skip>
   </properties>

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
@@ -20,8 +20,7 @@
       container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,
-      container.image.mongodb,
-      data-index-ephemeral.image.test
+      container.image.mongodb
     </invoker.test.properties.list>
     <!-- We DON'T want to skip main compilation, sources-zip is supposed to validate full build -->
     <maven.main.skip>false</maven.main.skip>


### PR DESCRIPTION
As tests have been moved to the kogito-apps, we should also move the overriding property.