### PR TITLE
BAQE-2898: Fix kogito-apps baseline not using correct images for testing

### DIFF
--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
@@ -17,15 +17,12 @@
     The entry in properties file is created only when the value for given property is passed using `-D` to the
     overall maven build. -->
     <invoker.test.properties.list>
-      container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,
-      container.image.mongodb,
       quarkus.container-image.build,
-      data-index-ephemeral.image.test,
-      data-index-postgresql.image.test,
-      job-service-ephemeral.image.test,
-      job-service-postgresql.image.test
+      container.image.data-index-service-postgresql,
+      container.image.jobs-service,
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <maven.main.skip>true</maven.main.skip>
   </properties>

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
@@ -17,15 +17,12 @@
     The entry in properties file is created only when the value for given property is passed using `-D` to the
     overall maven build. -->
     <invoker.test.properties.list>
-      container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,
-      container.image.mongodb,
-      quarkus.container-image.build,
-      data-index-ephemeral.image.test,
-      data-index-postgresql.image.test,
-      job-service-ephemeral.image.test,
-      job-service-postgresql.image.test
+      quarkus.container-image.build
+      container.image.data-index-service-postgresql,
+      container.image.jobs-service,
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <maven.main.skip>true</maven.main.skip>
   </properties>

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
@@ -19,7 +19,7 @@
     <invoker.test.properties.list>
       container.image.keycloak,
       container.image.kafka,
-      quarkus.container-image.build
+      quarkus.container-image.build,
       container.image.data-index-service-postgresql,
       container.image.jobs-service,
       data-index-ephemeral.image.test

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
@@ -17,15 +17,12 @@
          The entry in properties file is created only when the value for given property is passed using `-D` to the
          overall maven build. -->
     <invoker.test.properties.list>
-      container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,
-      container.image.mongodb,
       quarkus.container-image.build,
-      data-index-ephemeral.image.test,
-      data-index-postgresql.image.test,
-      job-service-ephemeral.image.test,
-      job-service-postgresql.image.test
+      container.image.data-index-service-postgresql,
+      container.image.jobs-service,
+      data-index-ephemeral.image.test
     </invoker.test.properties.list>
     <!-- We DON'T want to skip main compilation, sources-zip is supposed to validate full build -->
     <maven.main.skip>false</maven.main.skip>


### PR DESCRIPTION
Remove unused mongodb and infinispan container images 
Add postgresql image for data index common job service image
Fix previous mistakenlused labels