### PR TITLE
[srvlogic-9.100.x] BAQE-2903: Workarund, allow checkstyle.skip control

### DIFF
--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-local-repo-test/pom.xml
@@ -17,6 +17,7 @@
     The entry in properties file is created only when the value for given property is passed using `-D` to the
     overall maven build. -->
     <invoker.test.properties.list>
+      checkstyle.skip,
       container.image.keycloak,
       container.image.kafka,
       quarkus.container-image.build,

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-project-sources-test/pom.xml
@@ -17,6 +17,7 @@
     The entry in properties file is created only when the value for given property is passed using `-D` to the
     overall maven build. -->
     <invoker.test.properties.list>
+      checkstyle.skip,
       container.image.keycloak,
       container.image.kafka,
       quarkus.container-image.build,

--- a/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-apps-parent/kogito-apps-sources-zip-test/pom.xml
@@ -17,6 +17,7 @@
          The entry in properties file is created only when the value for given property is passed using `-D` to the
          overall maven build. -->
     <invoker.test.properties.list>
+      checkstyle.skip,
       container.image.keycloak,
       container.image.kafka,
       quarkus.container-image.build,

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-local-repo-test/pom.xml
@@ -17,6 +17,7 @@
     The entry in properties file is created only when the value for given property is passed using `-D` to the
     overall maven build. -->
     <invoker.test.properties.list>
+      checkstyle.skip,
       container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-project-sources-test/pom.xml
@@ -17,6 +17,7 @@
     The entry in properties file is created only when the value for given property is passed using `-D` to the
     overall maven build. -->
     <invoker.test.properties.list>
+      checkstyle.skip,
       container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,

--- a/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
+++ b/run-tests-with-build-kogito-runtimes-parent/kogito-runtimes-sources-zip-test/pom.xml
@@ -17,6 +17,7 @@
     The entry in properties file is created only when the value for given property is passed using `-D` to the
     overall maven build. -->
     <invoker.test.properties.list>
+      checkstyle.skip,
       container.image.infinispan,
       container.image.keycloak,
       container.image.kafka,


### PR DESCRIPTION
Allow this for to deal with compilation fails. Temporary workaround.