### PR TITLE
[BAQE-3125] Disable failing Drools kie-ci tests (#110)

### DIFF
--- a/run-tests-with-build-drools/pom.xml
+++ b/run-tests-with-build-drools/pom.xml
@@ -46,6 +46,7 @@
                 <excludeDirectory>.*drools-persistence.*</excludeDirectory>
                 <excludeDirectory>.*drools-impact.*</excludeDirectory>
                 <excludeDirectory>.*test-integration-nomvel.*</excludeDirectory>
+                <excludeDirectory>.*kie-ci.*</excludeDirectory>
               </excludeDirectories>
             </configuration>
           </execution>
@@ -62,6 +63,7 @@
             <pomExclude>drools/drools-persistence/pom.xml</pomExclude>
             <pomExclude>drools/drools-impact-analysis/pom.xml</pomExclude>
             <pomExclude>drools/test-integration-nomvel/pom.xml</pomExclude>
+            <pomExclude>drools/kie-ci/pom.xml</pomExclude>
           </pomExcludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Jira: [BAQE-3125](https://issues.redhat.com/browse/BAQE-3125)

Backported from https://github.com/kiegroup/run-tests-with-build/pull/110