### PR TITLE
[9.103.x][BAQE-3125] Exclude also drools-project-sources-test

### DIFF
--- a/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
+++ b/run-tests-with-build-drools-parent/drools-project-sources-test/pom.xml
@@ -83,6 +83,7 @@
           <pomExcludes>
             <!-- Excludes work still as expected. -->
             <pomExclude>**/kie-archetypes/**/archetype-resources/pom.xml</pomExclude>
+	    <pomExclude>**/kie-ci/**/pom.xml</pomExclude>
           </pomExcludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
Jira: [BAQE-3125](https://issues.redhat.com/browse/BAQE-3125)

Backported from https://github.com/kiegroup/run-tests-with-build/pull/114